### PR TITLE
add a class for managing tools

### DIFF
--- a/mesa_llm/tools/__init__.py
+++ b/mesa_llm/tools/__init__.py
@@ -1,2 +1,3 @@
 from .tool_manager import ToolManager
+
 __all__ = ["ToolManager"]

--- a/mesa_llm/tools/__init__.py
+++ b/mesa_llm/tools/__init__.py
@@ -1,0 +1,2 @@
+from .tool_manager import ToolManager
+__all__ = ["ToolManager"]

--- a/mesa_llm/tools/inbuilt_tools.py
+++ b/mesa_llm/tools/inbuilt_tools.py
@@ -1,2 +1,0 @@
-from .tool_manager import ToolManager
-__all__ = ["ToolManager"]

--- a/mesa_llm/tools/inbuilt_tools.py
+++ b/mesa_llm/tools/inbuilt_tools.py
@@ -1,0 +1,2 @@
+from .tool_manager import ToolManager
+__all__ = ["ToolManager"]

--- a/mesa_llm/tools/tool_manager.py
+++ b/mesa_llm/tools/tool_manager.py
@@ -1,0 +1,60 @@
+from typing import Callable, Dict, Any
+import inspect
+import json
+
+class ToolManager:
+    def __init__(self):
+        self.tools: Dict[str, Callable] = {}
+
+    def register(self, fn: Callable):
+        #Register a tool function by name
+        name = fn.__name__
+        self.tools[name] = fn
+
+    def get_schema(self) -> list[dict]:
+        #Return schema (have to make it liteLLM compatible)
+        schema = []
+        for name, fn in self.tools.items():
+            sig = inspect.signature(fn)
+            properties = {}
+            required = []
+            for param in sig.parameters.values():
+                properties[param.name] = {
+                    "type": "string",  #I have to use type-checking here
+                    "description": f"{param.name} parameter"
+                }
+                if param.default == inspect.Parameter.empty:
+                    required.append(param.name)
+            schema.append({
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "description": fn.__doc__ or "",
+                    "parameters": {
+                        "type": "object",
+                        "properties": properties,
+                        "required": required
+                    }
+                }
+            })
+        return schema
+
+    def call(self, name: str, arguments: dict) -> str:
+        """Call a registered tool with validated args"""
+        if name not in self.tools:
+            raise ValueError(f"Tool '{name}' not found")
+        return self.tools[name](**arguments)
+
+    def has_tool(self, name: str) -> bool:
+        return name in self.tools
+    
+'''Example Usage:
+
+tool_manager = ToolManager()
+
+@tool_manager.register
+def get_current_weather(location, unit="fahrenheit"):
+    """Get the current weather in a given location."""
+    return json.dumps({"location": location, "temperature": "22", "unit": unit})
+
+'''

--- a/mesa_llm/tools/tool_manager.py
+++ b/mesa_llm/tools/tool_manager.py
@@ -1,12 +1,11 @@
-from typing import Callable, Any
 import inspect
-import json
+from collections.abc import Callable
 
 """
-The user can use insntaces of ToolManager to regsiter functions as tools through the decorator (refer the example usage below).
-The user can also use the ToolManager instance to get the schema of the tools, call a tool with validated arguments, and check if a tool is registered.
-Moreover, the user can group like tools together by creating a new ToolManager instance and registering the tools to it. 
-So if agent A requires tools A1, A2, and A3, and agent B requires tools B1, B2, and B3, the user can create two ToolManager instances: tool_manager_A and tool_manager_B.
+    The user can use insntaces of ToolManager to regsiter functions as tools through the decorator (refer the example usage below).
+    The user can also use the ToolManager instance to get the schema of the tools, call a tool with validated arguments, and check if a tool is registered.
+    Moreover, the user can group like tools together by creating a new ToolManager instance and registering the tools to it. 
+    So if agent A requires tools A1, A2, and A3, and agent B requires tools B1, B2, and B3, the user can create two ToolManager instances: tool_manager_A and tool_manager_B.
 """
 
 class ToolManager:
@@ -48,7 +47,7 @@ class ToolManager:
                 if param.annotation != inspect.Parameter.empty:
                     annotation = param.annotation
 
-                    json_type = py_to_json_type.get(annotation, None)
+                    json_type = py_to_json_type.get(annotation)
 
                     if json_type:
                         param_schema["type"] = json_type
@@ -86,7 +85,7 @@ class ToolManager:
 
     def has_tool(self, name: str) -> bool:
         return name in self.tools
-    
+
 
 '''Example Usage:
 
@@ -111,4 +110,3 @@ if __name__ == "__main__":
 '''
 
 
-    

--- a/mesa_llm/tools/tool_manager.py
+++ b/mesa_llm/tools/tool_manager.py
@@ -1,30 +1,69 @@
-from typing import Callable, Dict, Any
+from typing import Callable, Any
 import inspect
 import json
 
+"""
+The user can use insntaces of ToolManager to regsiter functions as tools through the decorator (refer the example usage below).
+The user can also use the ToolManager instance to get the schema of the tools, call a tool with validated arguments, and check if a tool is registered.
+Moreover, the user can group like tools together by creating a new ToolManager instance and registering the tools to it. 
+So if agent A requires tools A1, A2, and A3, and agent B requires tools B1, B2, and B3, the user can create two ToolManager instances: tool_manager_A and tool_manager_B.
+"""
+
 class ToolManager:
     def __init__(self):
-        self.tools: Dict[str, Callable] = {}
+        self.tools: dict[str, Callable] = {}
 
     def register(self, fn: Callable):
-        #Register a tool function by name
+        """Register a tool function by name"""
         name = fn.__name__
-        self.tools[name] = fn
+        self.tools[name] = fn #storing the name & function pair as a dicitonary
 
     def get_schema(self) -> list[dict]:
-        #Return schema (have to make it liteLLM compatible)
+        """Return schema in the liteLLM format"""
+        #we need to convert the function signature from python to a JSON schema
+        py_to_json_type = {
+            str: "string",
+            int: "integer",
+            float: "number",
+            bool: "boolean",
+            list: "array",
+            dict: "object"
+        }
+
         schema = []
         for name, fn in self.tools.items():
             sig = inspect.signature(fn)
             properties = {}
             required = []
+
             for param in sig.parameters.values():
-                properties[param.name] = {
-                    "type": "string",  #I have to use type-checking here
+                if param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
+                    # skip *args and **kwargs
+                    continue
+                param_schema = {
                     "description": f"{param.name} parameter"
                 }
+
+                # If type annotation is available
+                if param.annotation != inspect.Parameter.empty:
+                    annotation = param.annotation
+
+                    json_type = py_to_json_type.get(annotation, None)
+
+                    if json_type:
+                        param_schema["type"] = json_type
+                    else:
+                        # fallback: allow any type
+                        param_schema["type"] = ["string", "number", "boolean", "object", "array", "null"]
+                else:
+                    # No annotation so fallback
+                    param_schema["type"] = ["string", "number", "boolean", "object", "array", "null"]
+
+                properties[param.name] = param_schema
+
                 if param.default == inspect.Parameter.empty:
                     required.append(param.name)
+
             schema.append({
                 "type": "function",
                 "function": {
@@ -37,7 +76,7 @@ class ToolManager:
                     }
                 }
             })
-        return schema
+        return schema #incase the user wants to change the something like say the parameter description, they will have to get the schema and edit it manually
 
     def call(self, name: str, arguments: dict) -> str:
         """Call a registered tool with validated args"""
@@ -48,13 +87,28 @@ class ToolManager:
     def has_tool(self, name: str) -> bool:
         return name in self.tools
     
+
 '''Example Usage:
 
-tool_manager = ToolManager()
+if __name__ == "__main__":
+    tool_manager = ToolManager()
 
-@tool_manager.register
-def get_current_weather(location, unit="fahrenheit"):
-    """Get the current weather in a given location."""
-    return json.dumps({"location": location, "temperature": "22", "unit": unit})
+    @tool_manager.register
+    def add_two_numbers(a: int, b: int) -> str:
+        """Takes two numbers and sums them up"""
+        c = a + b
+        return json.dumps({"a": a, "b": b, "c": c})
+    @tool_manager.register
+    def multiply_two_numbers(x: int, y: int) -> str:
+        """Takes two numbers and multiplies them"""
+        z = x * y
+        return json.dumps({"x": x, "y": y, "z": z})
+
+    print(tool_manager.get_schema())
+    print(tool_manager.call("add_two_numbers", {"a": 1, "b": 2}))
+    print(tool_manager.has_tool("add_two_numbers"))
 
 '''
+
+
+    

--- a/mesa_llm/tools/tool_manager.py
+++ b/mesa_llm/tools/tool_manager.py
@@ -2,9 +2,9 @@ import inspect
 from collections.abc import Callable
 
 """
-    The user can use insntaces of ToolManager to regsiter functions as tools through the decorator (refer the example usage below).
+    The user can use insntaces of ToolManager to regsiter functions as tools through the decorator.
     The user can also use the ToolManager instance to get the schema of the tools, call a tool with validated arguments, and check if a tool is registered.
-    Moreover, the user can group like tools together by creating a new ToolManager instance and registering the tools to it. 
+    Moreover, the user can group like tools together by creating a new ToolManager instance and registering the tools to it.
     So if agent A requires tools A1, A2, and A3, and agent B requires tools B1, B2, and B3, the user can create two ToolManager instances: tool_manager_A and tool_manager_B.
 """
 
@@ -86,27 +86,5 @@ class ToolManager:
     def has_tool(self, name: str) -> bool:
         return name in self.tools
 
-
-'''Example Usage:
-
-if __name__ == "__main__":
-    tool_manager = ToolManager()
-
-    @tool_manager.register
-    def add_two_numbers(a: int, b: int) -> str:
-        """Takes two numbers and sums them up"""
-        c = a + b
-        return json.dumps({"a": a, "b": b, "c": c})
-    @tool_manager.register
-    def multiply_two_numbers(x: int, y: int) -> str:
-        """Takes two numbers and multiplies them"""
-        z = x * y
-        return json.dumps({"x": x, "y": y, "z": z})
-
-    print(tool_manager.get_schema())
-    print(tool_manager.call("add_two_numbers", {"a": 1, "b": 2}))
-    print(tool_manager.has_tool("add_two_numbers"))
-
-'''
 
 


### PR DESCRIPTION
### The Issue
In the reasoning.py module (for in-context-learning methods) we will require the user to list out their tools following the schema below:
![image](https://github.com/user-attachments/assets/c7402e44-4cc8-449e-ac04-3ef2f633b3cd)
(The above image shows the structure while using liteLLM)
Since this can be quite painful, to repeat for each and every tool, I thought having a Tools manager class would be useful.

###  Functionality
- The user can use insntaces of ToolManager to regsiter functions as tools through the decorator (as shown in the example below).
- The user can also use the ToolManager instance to get the schema of the tools, call a tool, and check if a tool is registered.
- Moreover, the user can group like tools together by creating a new ToolManager instance and registering the tools to it. 
So if agent A requires tools A1, A2, and A3, and agent B requires tools B1, B2, and B3, the user can create two ToolManager instances: tool_manager_A and tool_manager_B.

### Example
Code:
```python
tool_manager = ToolManager()
@tool_manager.register
def add_two_numbers(a: int, b: int) -> str:
    """Takes two numbers and sums them up"""
    c = a + b
    return json.dumps({"a": a, "b": b, "c": c})
@tool_manager.register
def multiply_two_numbers(x: int, y: int) -> str:
    """Takes two numbers and multiplies them"""
    z = x * y
    return json.dumps({"x": x, "y": y, "z": z})

print(tool_manager.get_schema())
print(tool_manager.call("add_two_numbers", {"a": 1, "b": 2}))
print(tool_manager.has_tool("add_two_numbers"))
```
Output:
![image](https://github.com/user-attachments/assets/89d4d79e-4e48-404e-b828-60b0ebda050a)



