### PR TITLE
require python >= 3.11 following mesa

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, macos, windows]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
   rev: v3.19.1
   hooks:
     - id: pyupgrade
-      args: [--py310-plus]
+      args: [--py311-plus]
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v5.0.0  # Use the ref you want to point at
   hooks:

--- a/mesa_llm/__init__.py
+++ b/mesa_llm/__init__.py
@@ -14,5 +14,5 @@ __all__ = [
 __title__ = "Mesa-LLM"
 __version__ = "0.0.2"
 __license__ = "MIT"
-_this_year = datetime.datetime.now(tz=datetime.timezone.utc).date().year
+_this_year = datetime.datetime.now(tz=datetime.UTC).date().year
 __copyright__ = f"Copyright {_this_year} Project Mesa Team"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "Mesa-LLM"
 description = "Generative Agent-Based Modeling with Large Language Models Empowered Agents"
 license = { text = "MIT" }
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 authors = [
   { name = "Project Mesa Team", email = "projectmesa@googlegroups.com" },
 ]
@@ -65,7 +65,7 @@ testpaths = [
 
 [tool.ruff]
 line-length = 88
-target-version = "py310"
+target-version = "py311"
 lint.select = [
     # "ANN", # annotations TODO
     "B", # bugbear
@@ -111,7 +111,7 @@ extend-exclude = ["docs", "build"]
 convention = "google"
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.11"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true

--- a/tests/test_tool_manager.py
+++ b/tests/test_tool_manager.py
@@ -1,8 +1,3 @@
-import datetime
-import sys
-
-if sys.version_info < (3, 11):
-    datetime.UTC = datetime.timezone.utc
 from unittest.mock import Mock
 
 import pytest


### PR DESCRIPTION
Python 3.10 support was dropped from Mesa in https://github.com/projectmesa/mesa/pull/2474.