### PR TITLE
Unify the passing of memory into reasoning

### DIFF
--- a/mesa_llm/memory/lt_memory.py
+++ b/mesa_llm/memory/lt_memory.py
@@ -1,5 +1,4 @@
 import os
-from collections import deque
 from typing import TYPE_CHECKING
 
 from mesa_llm.memory.memory import Memory, MemoryEntry
@@ -65,7 +64,6 @@ class LongTermMemory(Memory):
 
         self.long_term_memory = self.llm.generate(prompt)
 
-    
     def process_step(self, pre_step: bool = False):
         """
         Process the step of the agent :
@@ -79,7 +77,7 @@ class LongTermMemory(Memory):
                 content=self.step_content,
                 step=None,
             )
-            self.buffer= new_entry
+            self.buffer = new_entry
             self.step_content = {}
             return
 
@@ -94,7 +92,6 @@ class LongTermMemory(Memory):
             self._update_long_term_memory()
             self.step_content = {}
 
-
         # Display the new entry
         if self.display:
             self.buffer.display()
@@ -105,5 +102,11 @@ class LongTermMemory(Memory):
         """
         return str(self.long_term_memory)
 
-    def __str__(self) -> str:
+    def get_prompt_ready(self) -> str:
         return f"Long term memory: \n{self.format_long_term()}"
+
+    def get_communication_history(self) -> str:
+        """
+        Get the communication history
+        """
+        return "communication history is in memory of the agent"

--- a/mesa_llm/memory/memory.py
+++ b/mesa_llm/memory/memory.py
@@ -1,9 +1,11 @@
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from rich.console import Console
 from rich.panel import Panel
 
+from mesa_llm.llm_agent import LLMAgent
 from mesa_llm.module_llm import ModuleLLM
 
 if TYPE_CHECKING:
@@ -66,7 +68,7 @@ class MemoryEntry:
             console.print(panel)
 
 
-class Memory:
+class Memory(ABC):
     """
     Create a memory generic parent class that can be used to create different types of memories
 
@@ -102,6 +104,18 @@ class Memory:
 
         self.step_content: dict = {}
         self.last_observation: dict = {}
+
+    @abstractmethod
+    def get_prompt_ready(self) -> str:
+        """
+        Get the memory in a format that can be used for reasoning
+        """
+
+    @abstractmethod
+    def get_communication_history(self) -> str:
+        """
+        Get the communication history in a format that can be used for reasoning
+        """
 
     def add_to_memory(self, type: str, content: dict):
         """

--- a/mesa_llm/memory/st_lt_memory.py
+++ b/mesa_llm/memory/st_lt_memory.py
@@ -153,5 +153,20 @@ class STLTMemory(Memory):
                 )
             return "\n".join(lines)
 
-    def __str__(self) -> str:
-        return f"Short term memory:\n {self.format_short_term()}\n\nLong term memory: \n{self.format_long_term()}"
+    def get_prompt_ready(self) -> str:
+        return [
+            f"Short term memory:\n {self.format_short_term()}",
+            f"Long term memory: \n{self.format_long_term()}",
+        ]
+
+    def get_communication_history(self) -> str:
+        """
+        Get the communication history
+        """
+        return "\n".join(
+            [
+                f"step {entry.step}: {entry.content['message']}\n\n"
+                for entry in self.short_term_memory
+                if "message" in entry.content
+            ]
+        )

--- a/mesa_llm/memory/st_memory.py
+++ b/mesa_llm/memory/st_memory.py
@@ -81,5 +81,17 @@ class ShortTermMemory(Memory):
                 )
             return "\n".join(lines)
 
-    def __str__(self) -> str:
+    def get_prompt_ready(self) -> str:
         return f"Short term memory:\n {self.format_short_term()}\n"
+
+    def get_communication_history(self) -> str:
+        """
+        Get the communication history
+        """
+        return "\n".join(
+            [
+                f"step {entry.step}: {entry.content['message']}\n\n"
+                for entry in self.short_term_memory
+                if "message" in entry.content
+            ]
+        )

--- a/mesa_llm/reasoning/react.py
+++ b/mesa_llm/reasoning/react.py
@@ -35,34 +35,10 @@ class ReActReasoning(Reasoning):
         return system_prompt
 
     def get_react_prompt(self, obs: Observation) -> list[str]:
-        if (
-            hasattr(self.agent.memory, "short_term_memory")
-            and self.agent.memory.short_term_memory
-        ):
-            last_communication = self.agent.memory.short_term_memory[-1].content.get(
-                "message", "No recent communication history"
-            )
-        else:
-            last_communication = "No recent communication history"
+        prompt_list = self.agent.memory.get_prompt_ready()
+        last_communication = self.agent.memory.get_communication_history()
 
-        prompt_list = []
-        if (
-            hasattr(self.agent.memory, "short_term_memory")
-            and self.agent.memory.short_term_memory
-        ):
-            prompt_list.extend(
-                [
-                    f"short term memory - step {i}: \n" + str(st_entry)
-                    for i, st_entry in enumerate(self.agent.memory.short_term_memory)
-                ]
-            )
-        if (
-            hasattr(self.agent.memory, "long_term_memory")
-            and self.agent.memory.long_term_memory
-        ):
-            prompt_list.append(
-                "long term memory: \n" + str(self.agent.memory.format_long_term())
-            )
+        prompt_list.append(last_communication)
         if obs:
             prompt_list.append("current observation: \n" + str(obs))
         if last_communication:


### PR DESCRIPTION
Enforce the modularity of memory by making it abstract (`Memory(ABC)`), and adding unified functions for all future memory implementations (decorated with `@abstractmethod` : 
- get_prompt_ready(self) -> str
- get_communication_history(self) -> str

Both of which are being called in reasoning methods (only react right now, will add the rest in future commits)

I tested it a little bit, but if anybody could run it on example and stuff to make  sure that everything works fine, it would be great ! Behaviour should be exactly the same as before.