### PR TITLE
docs: Add examples page and expand API documentation structure

### DIFF
--- a/docs/apis/api_main.md
+++ b/docs/apis/api_main.md
@@ -4,4 +4,11 @@
 ---
 maxdepth: 3
 ---
+llm_agent
+module_llm
+memory
+reasoning
+tools
+recording
+parallel_stepping
 ```

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,12 +1,27 @@
+# Examples
 
-# Mesa-LLM Core Examples
-The examples folder contains a curated set of classic llm-agent-based models implemented using Mesa-LLM. These core examples are maintained by the Mesa-LLM development team and serve as both demonstrations of Mesa-LLM's capabilities and starting points for your own models.
+The examples folder contains LLM agent-based models implemented using Mesa-LLM. They serve as  demonstrations of Mesa-LLM's capabilities and starting points for your own models.
 
 This folder contains both basic and advanced examples that demonstrate different aspects of Mesa-LLM.
 
-### Epstein Civil Violence Model
+## Epstein Civil Violence Model
+
 Joshua Epstein's [model](https://www.pnas.org/doi/10.1073/pnas.092080199) of how a decentralized uprising can be suppressed or reach a critical mass of support.
 
-### Negotiation Model
+**Location:** [examples/epstein_civil_violence](https://github.com/projectmesa/mesa-llm/tree/main/examples/epstein_civil_violence)
+
+This example demonstrates:
+- Agent decision-making based on social dynamics
+- LLM-powered agent reasoning in conflict scenarios
+- Integration of multiple agent types with different behaviors
+
+## Negotiation Model
+
 Implementation of a negotiation model where two types of agents (buyer and seller) negotiate over a product.
 
+**Location:** [examples/negotiation](https://github.com/projectmesa/mesa-llm/tree/main/examples/negotiation)
+
+This example demonstrates:
+- Agent-to-agent communication
+- LLM-based negotiation strategies
+- Dynamic pricing and offer-counteroffer mechanisms

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,6 +66,7 @@ hidden: true
 ---
 Introduction <self>
 API Documentation <apis/api_main>
+Examples <examples>
 ```
 
 ## Indices and tables


### PR DESCRIPTION
### Summary
Added a dedicated Examples page to the documentation and expanded the API documentation structure with new module references.

### Motive
The documentation was missing a clear entry point for users to discover and understand example implementations. Additionally, the API documentation structure needed to include references to key modules (LLM agent, memory, reasoning, tools, recording, and parallel stepping) to provide comprehensive coverage of the framework's capabilities.

### Implementation
- Created a new `examples.md` page with detailed descriptions of the Epstein Civil Violence and Negotiation models
- Added direct links to example repositories on GitHub
- Included "demonstrates" sections for each example to highlight key learning points
- Extended `api_main.md` to reference 7 core modules in the documentation tree
- Added the Examples page to the main documentation index