### PR TITLE
fix: treat ollama_chat as ollama provider

### DIFF
--- a/mesa_llm/module_llm.py
+++ b/mesa_llm/module_llm.py
@@ -46,7 +46,7 @@ class ModuleLLM:
         self.system_prompt = system_prompt
         provider = self.llm_model.split("/")[0].upper()
 
-        if provider == "OLLAMA":
+        if provider in ["OLLAMA", "OLLAMA_CHAT"]:
             if self.api_base is None:
                 self.api_base = "http://localhost:11434"
                 console.print(


### PR DESCRIPTION
Hi, when I'm testing my tutorial, I found that the Function Calling (Tool Use) did not work. After further investigation, I identified the following issue.

### Summary
Added support for the `ollama_chat/` model prefix in `mesa_llm/module_llm.py` to enable proper Function Calling (Tool Use) with Ollama models.

### Bug / Issue

**Context**:  
Ollama exposes two different inference endpoints, which serve different interaction semantics:

- `/api/generate`: a single-turn text generation endpoint without structured chat semantics.  
  This endpoint corresponds to the default `ollama/<model>` usage in LiteLLM and is suitable for simple, one-shot generation without tool calling.
- `/api/chat`: a chat-oriented endpoint that supports multi-role messages (`system`, `user`, `assistant`) and is required for OpenAI-compatible features such as tool / function calling.

In LiteLLM, these two behaviors are distinguished by model prefixes:
- `ollama/<model>` routes requests to Ollama’s `/api/generate` endpoint.
- `ollama_chat/<model>` routes requests to Ollama’s `/api/chat` endpoint.

[The LiteLLM documentation](https://docs.litellm.ai/docs/providers/ollama) explicitly **recommends using the `ollama_chat/` prefix for chat-style interactions**, as it provides better support for conversational context and advanced features such as tool / function callinghttps://docs.litellm.ai/docs/providers/ollama.

**Problem**:  
The existing `ModuleLLM` initialization logic only recognized `"OLLAMA"` as a valid local provider that does not require an API key. When users followed LiteLLM’s recommendation and attempted to use `"ollama_chat/..."` to enable tool calling:

1. The provider string was parsed as `"OLLAMA_CHAT"` via `llm_model.split("/")[0].upper()`.
2. The code failed to recognize `"OLLAMA_CHAT"` as a local Ollama-backed provider.
3. It incorrectly entered the non-Ollama branch and attempted to validate an `OLLAMA_CHAT_API_KEY`.
4. Since local Ollama inference does not require an API key, this resulted in a crash (`KeyError` / `ValueError`) during initialization.


**Problem**:  
The existing `ModuleLLM` initialization logic only recognized `"OLLAMA"` as a valid local provider that does not require an API key. When users followed LiteLLM’s recommendation and attempted to use `"ollama_chat/..."` to enable tool calling:

1. The provider string was parsed as `"OLLAMA_CHAT"` via `llm_model.split("/")[0].upper()`.
2. The code failed to recognize `"OLLAMA_CHAT"` as a local Ollama-backed provider.
3. It incorrectly entered the non-Ollama branch and attempted to validate an `OLLAMA_CHAT_API_KEY`.
4. Since local Ollama inference does not require an API key, this resulted in a crash (`KeyError` / `ValueError`) during initialization.


### Implementation
Updated `mesa_llm/module_llm.py` to treat `OLLAMA_CHAT` as a valid local provider:
- **Change**: Modified the provider check `if provider == "OLLAMA":` to `if provider in ["OLLAMA", "OLLAMA_CHAT"]:`.
- **Effect**: This allows users to pass model strings like `"ollama_chat/qwen3:14b"` to `ModuleLLM`. The system now correctly:
    - Identifies it as a local Ollama model.
    - Skips the unnecessary API key check.
    - Uses the default local API base (`http://localhost:11434`).
    - Passes the `ollama_chat/` prefix to `litellm`, enabling robust function calling capabilities.

### Testing

Testing: Created a standalone script to validate function calling with LiteLLM and Ollama. The script defines a mock weather tool and verifies the model’s ability to emit correct tool calls. The results confirm that structured tool-calling output is only produced when using the ollama_chat/ prefix, while the standard ollama/ prefix fails to trigger tool invocation.

``` python
import json
import os
import litellm
from litellm import completion

# Enable verbose logging to see the payload sent to Ollama
os.environ['LITELLM_LOG'] = 'DEBUG'

# 1. Define the tool (function) we want the model to call
def get_current_weather(city):
    """
    Get the current weather for a given city.
    """
    print(f"\n[System] Executing get_current_weather for {city}...")
    # Mock data for demonstration
    if 'beijing' in city.lower():
        return json.dumps({"location": city, "temperature": "20", "unit": "celsius", "condition": "Sunny"})
    elif 'san francisco' in city.lower():
        return json.dumps({"location": city, "temperature": "60", "unit": "fahrenheit", "condition": "Cloudy"})
    elif 'paris' in city.lower():
        return json.dumps({"location": city, "temperature": "15", "unit": "celsius", "condition": "Rainy"})
    else:
        return json.dumps({"location": city, "temperature": "unknown"})

# Map function names to actual functions
available_functions = {
    'get_current_weather': get_current_weather,
}

# 2. Define the tool schema (OpenAI format for Litellm)
tools = [
    {
        'type': 'function',
        'function': {
            'name': 'get_current_weather',
            'description': 'Get the current weather for a city',
            'parameters': {
                'type': 'object',
                'properties': {
                    'city': {
                        'type': 'string',
                        'description': 'The name of the city, e.g. Beijing, San Francisco',
                    },
                },
                'required': ['city'],
            },
        },
    },
]

# Note: Use 'ollama_chat/' prefix to ensure LiteLLM uses the /api/chat endpoint with tool support
model_name = "ollama/qwen3:14b"
user_prompt = "What is the weather in Beijing today?"

print(f"--- Starting Litellm Tool Call Test with {model_name} ---")
print(f"User Prompt: {user_prompt}")

try:
    # 3. First call: Send the prompt and tools to the model
    response = completion(
        model=model_name,
        messages=[{'role': 'user', 'content': user_prompt}],
        tools=tools,
        tool_choice="auto" 
    )

    print("\n--- Model Response (First Pass) ---")
    message = response.choices[0].message
    
    # Check if the model decided to call a tool
    if message.tool_calls:
        print(f"Tool calls detected: {len(message.tool_calls)}")
        
        # 4. Process tool calls
        # We need to construct the messages list for the next call
        # It must include the original user message and the model's response (with tool calls)
        messages = [{'role': 'user', 'content': user_prompt}, message]
        
        for tool_call in message.tool_calls:
            function_name = tool_call.function.name
            function_args_str = tool_call.function.arguments
            
            print(f"Function Name: {function_name}")
            print(f"Raw Arguments: {function_args_str}")
            
            try:
                function_args = json.loads(function_args_str)
            except json.JSONDecodeError:
                # Some models might return a python dict string or weird format, 
                # but well-behaved ones return JSON.
                print(f"Warning: Could not parse JSON arguments, trying direct usage or fixing...")
                function_args = {} # Handle error appropriately in production

            print(f"Parsed Arguments: {function_args}")
            
            if function_name in available_functions:
                function_to_call = available_functions[function_name]
                function_response = function_to_call(**function_args)
                
                print(f"Function Output: {function_response}")
                
                # Add the tool execution result to the conversation history
                # Litellm/OpenAI expects a message with role 'tool', the 'tool_call_id', and content
                messages.append({
                    'role': 'tool',
                    'tool_call_id': tool_call.id,
                    'content': function_response,
                    'name': function_name
                })
            else:
                print(f"Error: Function {function_name} not found.")

        # 5. Second call: Send the tool results back to the model for the final answer
        print("\n--- Sending Tool Output back to Model ---")
        final_response = completion(
            model=model_name,
            messages=messages,
        )
        print("\n--- Final Answer ---")
        print(final_response.choices[0].message.content)
        
    else:
        print("No tool calls were made. The model responded directly:")
        print(message.content)

except Exception as e:
    print(f"\n[Error] An error occurred: {e}")
    print("Please ensure Ollama is running and Litellm is installed.")
```
### Additional Notes

I also evaluated the same model using the native Ollama API (without LiteLLM) to rule out model capacity or quantization as the cause. The results show that tool calling works correctly.
