### PR TITLE
test: update module_llm tests for system prompt handling (None -> "")

### DIFF
--- a/tests/test_module_llm.py
+++ b/tests/test_module_llm.py
@@ -57,7 +57,7 @@ class TestModuleLLM:
         llm = ModuleLLM(llm_model="openai/gpt-4o")
         messages = llm.get_messages("Hello, how are you?")
         assert messages == [
-            {"role": "system", "content": None},
+            {"role": "system", "content": ""},
             {"role": "user", "content": "Hello, how are you?"},
         ]
 
@@ -66,7 +66,7 @@ class TestModuleLLM:
             ["Hello, how are you?", "What is the weather in Tokyo?"]
         )
         assert messages == [
-            {"role": "system", "content": None},
+            {"role": "system", "content": ""},
             {"role": "user", "content": "Hello, how are you?"},
             {"role": "user", "content": "What is the weather in Tokyo?"},
         ]
@@ -92,8 +92,9 @@ class TestModuleLLM:
         ]
 
         # Test get_messages no system prompt and no prompt
+        llm = ModuleLLM(llm_model="openai/gpt-4o")
         messages = llm.get_messages(prompt=None)
-        assert messages == [{"role": "system", "content": None}]
+        assert messages == [{"role": "system", "content": ""}]
 
     def test_generate(self, monkeypatch):
         # Prevent network calls by stubbing litellm completion


### PR DESCRIPTION
### Summary
Updates existing tests to align with the system prompt handling behavior introduced in the previous fix. This ensures the test suite correctly reflects the normalized handling of empty system prompts.

### Bug / Issue
This PR is a follow-up to **#41 (Fix Ollama tool calling crash when system prompt is None)**.

In PR #41, the runtime crash was resolved by normalizing the system prompt when it is `None`. However, some existing tests still assumed the old behavior, causing a mismatch between the implementation and the test expectations.

### Implementation
- Updated existing tests in `test_module_llm.py` to align with the current behavior where an empty or missing system prompt is normalized to an empty string (`None -> ""`) for Ollama models.
- No changes were made to the core implementation logic; this PR strictly updates test expectations to match the corrected behavior.

### Testing
- Ran the updated test suite locally with `pytest` and `pre-commit`.

### Additional Notes
N/A