### PR TITLE
add error handling to move one step tool

### DIFF
--- a/mesa_llm/tools/inbuilt_tools.py
+++ b/mesa_llm/tools/inbuilt_tools.py
@@ -42,6 +42,11 @@ def move_one_step(agent: "LLMAgent", direction: str) -> str:
         Returns:
             A string confirming the result of the movement attempt.
     """
+    if direction not in direction_map:
+        raise ValueError(
+            f"Invalid direction '{direction}'."
+            f"Must be one of {list(direction_map.keys())}"
+        )
     dx, dy = direction_map[direction]
     x, y = agent.pos
     new_pos = (x + dx, y + dy)

--- a/tests/test_tools/test_inbuilt_tools.py
+++ b/tests/test_tools/test_inbuilt_tools.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
 from mesa.discrete_space import OrthogonalMooreGrid
 from mesa.space import MultiGrid, SingleGrid
 
@@ -107,3 +108,15 @@ def test_speak_to_records_on_recipients(mocker):
 
     # Return string contains sender and recipients list
     assert "10" in ret and "11" in ret and "12" in ret and message in ret
+
+
+def test_move_one_step_invalid_direction():
+    model = DummyModel()
+    model.grid = MultiGrid(width=4, height=4, torus=False)
+
+    agent = DummyAgent(unique_id=3, model=model)
+    model.agents.append(agent)
+    model.grid.place_agent(agent, (2, 2))
+
+    with pytest.raises(ValueError):
+        move_one_step(agent, "north east")


### PR DESCRIPTION
### Summary
<!-- Provide a brief summary of the bug and its impact. -->
The move_one_step tool currently assumes the direction argument will always be one of the documented values (`North`,` South`, `East` etc.) and directly indexes into `direction_map`. This is in contrast to the tools used in Mesa LLM examples that raise `ValueError()` for invalid arguments.

### Bug / Issue
<!-- Link to the related issue(s) and describe the bug. Include details like the context, what was expected, and what actually happened. -->
This is described in #54. 

### Implementation
<!-- Describe the changes made to resolve the issue. Highlight any important parts of the code that were modified. -->
The tool now raises a `ValueError` in case an invalid direction is provided by an LLM or user.

### Testing
<!-- Detail the testing performed to verify the fix. Include information on test cases, steps taken, and any relevant results.-->
 
The test `test_move_one_step_invalid_direction()` has been added to verify the updated behaviour.
