### PR TITLE
docs: add orphaned pages to toctree in index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -65,6 +65,10 @@ maxdepth: 2
 hidden: true
 ---
 Introduction <self>
+Overview <overview>
+Getting Started <getting_started>
+First Model Tutorial <first_model>
+Negotiation Model Tutorial <negotiation_model_tutorial>
 Examples <examples>
 API Documentation <apis/api_main>
 ```


### PR DESCRIPTION
### Summary

The `docs/index.md` toctree only linked three pages (Introduction, Examples, API Documentation), leaving four existing documentation pages as orphans not reachable from the sidebar navigation:

- `overview.md` - Feature overview
- `getting_started.md` - Getting started guide
- `first_model.md` - First model tutorial
- `negotiation_model_tutorial.md` - Negotiation model tutorial

This PR adds all four pages to the toctree in a logical order, making them accessible in the built documentation.

### Testing

- Verified the Sphinx build completes successfully with the updated toctree
- All four pages are now included in the generated HTML output
- No new warnings introduced by this change

Addresses #31