### PR TITLE
reorganize readthedocs folder structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ pip install -U -e git+https://github.com/YOUR_FORK/mesa-llm@YOUR_BRANCH#egg=mesa
 
 For more help on using Mesa-LLM, check out the following resources:
 
-- [Introductory Tutorial](https://mesa-llm.readthedocs.io/en/stable/first_model.html)
+- [Getting Started](http://mesa-llm.readthedocs.io/en/stable/getting_started.html)
 - [Docs](http://mesa-llm.readthedocs.io/)
 - [Mesa-LLM Discussions](https://github.com/mesa/mesa-llm/discussions)
 - [PyPI](https://pypi.org/project/mesa-llm/)

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,31 +1,31 @@
 # Getting Started
-Mesa-llm is an extension of the Mesa agent-based modeling framework that enables language-model-based reasoning inside agents, while preserving Mesa’s execution model, scheduling, and environments.
+Mesa-LLM is an extension of the Mesa agent-based modeling framework that enables language-model-based reasoning inside agents, while preserving Mesa’s execution model, scheduling, and environments.
 
-Mesa-llm allows agents to reason using natural language prompts, enabling more flexible, interpretable, and adaptive decision-making within structured simulations.
+Mesa-LLM allows agents to reason using natural language prompts, enabling more flexible, interpretable, and adaptive decision-making within structured simulations.
 
-Agents in mesa-llm are still standard Mesa agents. The only difference is how decisions are made, not how models run.
+Agents in Mesa-LLM are still standard Mesa agents. The only difference is how decisions are made, not how models run.
 
 ## Overview
-If you want a high-level understanding of mesa-llm structure and capabilities, start here:
-- [Overview of Mesa-llm Library](https://github.com/mesa/mesa-llm/blob/main/docs/overview.md)
+If you want a high-level understanding of Mesa-LLM structure and capabilities, start here:
+- [Overview of Mesa-LLM Library](overview.md)
 
 ## Tutorials
-If you want to learn mesa-llm step by step, follow these tutorials:
-- [Creating your First Mesa-llm Model](https://github.com/mesa/mesa-llm/blob/main/docs/first_model.md)
+If you want to learn Mesa-LLM step by step, follow these tutorials:
+- [Creating your First Mesa-LLM Model](tutorials/first_model.md)
 Learn how to define a minimal LLMAgent that reasons using an LLM while remaining a standard Mesa agent.
 
-- [Negotiation Model Tutorial](https://github.com/mesa/mesa-llm/blob/main/docs/negotiation_model_tutorial.md)
+- [Negotiation Model Tutorial](tutorials/negotiation_model_tutorial.md)
 Learn how multiple LLM-powered agents reason, communicate, and negotiate within a shared model.
 
 ## Examples
-Mesa-llm ships with example models demonstrating how language-based reasoning integrates with classic agent-based modeling patterns.
+Mesa-LLM ships with example models demonstrating how language-based reasoning integrates with classic agent-based modeling patterns.
 
 These examples are useful if you are already familiar with Mesa and want to see how LLM-powered agents behave in practice. You can find them here:
-[Mesa-llm Examples](https://github.com/mesa/mesa-llm/tree/main/examples)
+[Mesa-LLM Examples](examples.md)
 
 ## Source Code
-- [Mesa-llm Github Repository](https://github.com/mesa/mesa-llm)
+- [Mesa-LLM Github Repository](https://github.com/mesa/mesa-llm)
 
 ## Community and Support
-- [Mesa-llm Discussion](https://github.com/mesa/mesa-llm/discussions)
+- [Mesa-LLM Discussion](https://github.com/mesa/mesa-llm/discussions)
 - [Matrix Chat Room](https://matrix.to/#/#mesa-llm:matrix.org)

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 | | |
 | --- | --- |
-| CI/CD | [![GitHub CI](https://github.com/mesa/mesa-llm/workflows/build/badge.svg)](https://github.com/mesa/mesa-llm/actions) [![Read the Docs](https://readthedocs.org/projects/mesa-llm/badge/?version=stable)](https://mesa-llm.readthedocs.io/stable) [![Codecov](https://codecov.io/gh/projectmesa/mesa-llm/branch/main/graph/badge.svg)](https://codecov.io/gh/projectmesa/mesa-llm) |
+| CI/CD | [![GitHub CI](https://github.com/mesa/mesa-llm/workflows/build/badge.svg)](https://github.com/mesa/mesa-llm/actions) [![Read the Docs](https://readthedocs.org/projects/mesa-llm/badge/?version=stable)](https://mesa-llm.readthedocs.io/) [![Codecov](https://codecov.io/gh/projectmesa/mesa-llm/branch/main/graph/badge.svg)](https://codecov.io/gh/projectmesa/mesa-llm) |
 | Package | [![PyPI](https://img.shields.io/pypi/v/mesa-llm.svg)](https://pypi.org/project/mesa-llm) [![PyPI - License](https://img.shields.io/pypi/l/mesa-llm)](https://pypi.org/project/mesa-llm/) [![PyPI - Downloads](https://img.shields.io/pypi/dw/mesa-llm)](https://pypistats.org/packages/mesa-llm) |
 | Meta | [![linting - Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff) [![code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black) [![Hatch project](https://img.shields.io/badge/%F0%9F%A5%9A-Hatch-4051b5.svg)](https://github.com/pypa/hatch) |
 | Chat | [![chat](https://img.shields.io/matrix/mesa-llm:matrix.org?label=chat&logo=Matrix)](https://matrix.to/#/#mesa-llm:matrix.org) |
@@ -36,10 +36,23 @@ pip install -U -e git+https://github.com/YOUR_FORK/mesa-llm@YOUR_BRANCH#egg=mesa
 
 For more help on using Mesa-LLM, check out the following resources:
 
-- [Introductory Tutorial](http://mesa-llm.readthedocs.io/stable/tutorials/intro_tutorial.html)
-- [Docs](http://mesa-llm.readthedocs.io/stable/)
+- [Getting Started](http://mesa-llm.readthedocs.io/en/stable/getting_started.html)
+- [Docs](http://mesa-llm.readthedocs.io/)
 - [Mesa-LLM Discussions](https://github.com/mesa/mesa-llm/discussions)
 - [PyPI](https://pypi.org/project/mesa-llm/)
+
+## Using Mesa-LLM
+
+Mesa-LLM supports the following LLM models :
+
+- OpenAI
+- Anthropic
+- xAI
+- Huggingface
+- Ollama
+- OpenRouter
+- NovitaAI
+- Gemini
 
 ## Contributing to Mesa-LLM
 
@@ -57,18 +70,14 @@ A feature is most likely to be added if you build it!
 
 Don't forget to check out the [Contributors guide](https://github.com/mesa/mesa-llm/blob/main/CONTRIBUTING.md).
 
-
-
 ```{toctree}
 ---
 maxdepth: 2
 hidden: true
 ---
-Introduction <self>
-Overview <overview>
 Getting Started <getting_started>
-First Model Tutorial <first_model>
-Negotiation Model Tutorial <negotiation_model_tutorial>
+Overview <overview>
+Tutorials <tutorials/index>
 Examples <examples>
 API Documentation <apis/api_main>
 ```

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,6 +1,6 @@
 # Overview
-[Mesa-llm](https://github.com/mesa/mesa-llm) is an extension of [Mesa](https://github.com/mesa) that enables language-model-based reasoning inside agents. It does not modify Mesa’s execution model, scheduling, or environments.
-Agents created with mesa-llm are standard Mesa agents. The only difference is that their decision-making logic is delegated to a reasoning component backed by an LLM.
+[Mesa-LLM](https://github.com/mesa/mesa-llm) is an extension of [Mesa](https://github.com/mesa) that enables language-model-based reasoning inside agents. It does not modify Mesa’s execution model, scheduling, or environments.
+Agents created with Mesa-LLM are standard Mesa agents. The only difference is that their decision-making logic is delegated to a reasoning component backed by an LLM.
 
 ## Separation
 ### What Mesa Provides
@@ -17,7 +17,7 @@ Agents created with mesa-llm are standard Mesa agents. The only difference is th
 
 ## Core Mesa-llm Concepts
 #### 1. LLMAgent
-`LLMAgent` is the core abstraction introduced by mesa-llm.
+`LLMAgent` is the core abstraction introduced by Mesa-LLM.
 From Mesa’s perspective, an LLMAgent behaves exactly like a standard Mesa Agent:
 - It is created and registered in the same way.
 - It is scheduled and activated using Mesa’s normal execution flow.
@@ -36,16 +36,16 @@ A reasoning module defines how an agent thinks, given:
 - Observations from the model or environment.
 - Optional memory and tools.
 
-Reasoning modules are attached to agents to encapsulate how language-based reasoning is performed. While mesa-llm currently provides `ReActReasoning`, the reasoning logic is kept separate from the agent to allow extensibility without changing agent structure.
+Reasoning modules are attached to agents to encapsulate how language-based reasoning is performed. While Mesa-LLM currently provides `ReActReasoning`, the reasoning logic is kept separate from the agent to allow extensibility without changing agent structure.
 
 #### 3. Memory
 Memory allows agents to retain information across simulation steps.
-In mesa-llm, memory is useful for reasoning-based agents. It enables agents to:
+In Mesa-LLM, memory is useful for reasoning-based agents. It enables agents to:
 - Reference past observations or interactions.
 - Maintain more consistent behavior over time.
 - Produce more coherent and contextual reasoning.
 
-Memory is optional in mesa-llm. When present, it allows agents to retain information across steps and reason with context. When absent, agents reason purely from the current observation and prompt.
+Memory is optional in Mesa-LLM. When present, it allows agents to retain information across steps and reason with context. When absent, agents reason purely from the current observation and prompt.
 
 #### 4. Tools
 Tools provide a structured way for agents to express or request actions when the simulation supports action execution.
@@ -54,12 +54,12 @@ Tools are optional and typically become relevant only when:
 - An environment exists (e.g. a grid).
 - Actions can be meaningfully executed.
 
-In introductory models, action suggestions may appear only as part of the reasoning trace and are not executed. Mesa-llm does not introduce new space or environment abstractions; it relies entirely on Mesa’s existing space modules.
+In introductory models, action suggestions may appear only as part of the reasoning trace and are not executed. Mesa-LLM does not introduce new space or environment abstractions; it relies entirely on Mesa’s existing space modules.
 
 #### 5. Execution Model
-Mesa-llm follows Mesa’s standard execution model.
+Mesa-LLM follows Mesa’s standard execution model.
 The simulation advances through calls to `model.step()`, and agents are activated using Mesa’s scheduling mechanisms.
 
 When an agent is activated, its `step()` method is called.
-In mesa-llm, this method typically includes language-based reasoning before deciding what to do next.
+In Mesa-LLM, this method typically includes language-based reasoning before deciding what to do next.
 

--- a/docs/tutorials/first_model.md
+++ b/docs/tutorials/first_model.md
@@ -1,23 +1,23 @@
-# Creating Your First mesa-llm Model
+# Creating Your First Mesa-LLM Model
 
 ## Tutorial Overview
-This tutorial introduces mesa-llm by walking through the construction of a simple language-driven agent model built on top of Mesa. Mesa-llm enables agents to reason using natural language while preserving Mesa’s standard execution model. If it's your first time using mesa, we suggest starting with the classic [creating your first model tutorials](https://mesa.readthedocs.io/latest/tutorials/0_first_model.html) before diving into mesa-llm.
+This tutorial introduces Mesa-LLM by walking through the construction of a simple language-driven agent model built on top of Mesa. Mesa-LLM enables agents to reason using natural language while preserving Mesa’s standard execution model. If it's your first time using mesa, we suggest starting with the classic [creating your first model tutorials](https://mesa.readthedocs.io/en/stable/tutorials/0_first_model.html) before diving into Mesa-LLM.
 
 The goal of this tutorial is **not** to build a complex simulation or environment.
-Instead, it focuses on the **core idea** behind mesa-llm:
+Instead, it focuses on the **core idea** behind Mesa-LLM:
 
 > How language-based reasoning can be embedded into Mesa’s standard agent execution workflow.
 
 By the end of this tutorial, you will understand:
 - What `LLMAgent` is
-- How mesa-llm integrates with Mesa models
+- How Mesa-LLM integrates with Mesa models
 - How agents perform language-based reasoning at each step
 - Why some reasoning strategies also suggest actions
 - How to structure a clean, extensible starting model
 
-## About mesa-llm
+## About Mesa-LLM
 
-[Mesa LLM](https://github.com/mesa/mesa-llm) is a set of tools that integrates Large Language Models (LLMs) with [Agent-based modeling](https://en.wikipedia.org/wiki/Agent-based_model) using the Mesa framework. Agents use natural language to reason about their state and prompts.
+[Mesa-LLM](https://github.com/mesa/mesa-llm) is a set of tools that integrates Large Language Models (LLMs) with [Agent-based modeling](https://en.wikipedia.org/wiki/Agent-based_model) using the Mesa framework. Agents use natural language to reason about their state and prompts.
 
 This approach is particularly useful for exploring how complex or emergent
 behavior can arise from language-driven agents in simulated systems.
@@ -25,7 +25,7 @@ By combining Mesa’s structured simulation framework with LLM-based reasoning,
 Mesa-LLM allows researchers and developers to experiment with more flexible,
 human-like agent behavior.
 
-While mesa-llm adds:
+While Mesa-LLM adds:
 - Prompt-driven reasoning
 - Reasoning strategies (e.g. ReAct)
 - Optional memory components for contextual reasoning across steps
@@ -48,15 +48,15 @@ Action execution and environments are intentionally deferred to later tutorials.
 ## Tutorial Setup
 Create and activate a virtual environment. Python version 3.12 or higher is required.
 
-## Install mesa-llm and required packages
+## Install Mesa-LLM and required packages
 
-Install mesa-llm
+Install Mesa-LLM
 
 ```bash
 pip install -U mesa-llm
 ```
 
-Mesa-llm pre-releases can be installed with:
+Mesa-LLM pre-releases can be installed with:
 ```bash
 pip install -U --pre mesa-llm
 ```
@@ -72,7 +72,7 @@ pip install -U -e git+https://github.com/YOUR_FORK/mesa-llm@YOUR_BRANCH#egg=mesa
 ```
 
 ## Building the Model
-After mesa-llm is installed, a 'model' can be built.
+After Mesa-LLM is installed, a 'model' can be built.
 This tutorial can be followed in a regular Python script or in a [Jupyter](https://jupyter.org/) notebook.
 
 
@@ -135,7 +135,7 @@ class SimpleAgent(LLMAgent):
 The 'model' manages agent creation and advances the simulation.
 
 'Agent' are created using the `create_agents()` helper provided by Mesa.
-mesa-llm integrates with this mechanism by allowing `LLMAgent` to be used
+Mesa-LLM integrates with this mechanism by allowing `LLMAgent` to be used
 wherever a standard Mesa `Agent` is expected.
 
 `LLMAgent` is a thin wrapper around Mesa’s base `Agent` class, which is why

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,0 +1,12 @@
+# Tutorials
+
+Step-by-step guides to build models with Mesa-LLM.
+
+```{toctree}
+---
+maxdepth: 1
+hidden: true
+---
+first_model
+negotiation_model_tutorial
+```

--- a/docs/tutorials/negotiation_model_tutorial.md
+++ b/docs/tutorials/negotiation_model_tutorial.md
@@ -1,9 +1,9 @@
-# Negotiation Model Tutorial (mesa-llm)
+# Negotiation Model Tutorial
 
 ## About This Tutorial
 
 This tutorial is inspired by the official
-[Mesa-llm Negotiation Example](https://github.com/mesa/mesa-llm/tree/main/examples/negotiation)
+[Mesa-LLM Negotiation Example](https://github.com/mesa/mesa-llm/tree/main/examples/negotiation)
 
 The goal here is **not to replicate** the original example, but to present a **simplified and tutorial-friendly version** that focuses on reasoning structure and agent interaction.
 
@@ -13,7 +13,7 @@ Key differences from the original example include:
 - No spatial environment or grid
 - Emphasis on understanding ReAct reasoning output
 
-This makes the example easier to follow for new users while still demonstrating core mesa-llm concepts.
+This makes the example easier to follow for new users while still demonstrating core Mesa-LLM concepts.
 
 ## Model Description
 
@@ -37,9 +37,9 @@ This `Model` simulates a basic negotiation scenario involving:
 ## Tutorial Setup
 Ensure you are using Python 3.12 or later.
 
-## Install mesa-llm and required packages
+## Install Mesa-LLM and required packages
 
-Install mesa-llm
+Install Mesa-LLM
 
 ```bash
 pip install -U mesa-llm
@@ -62,7 +62,7 @@ The console output displays the internal reasoning traces.
 
 ## Agent Messaging
 In negotiation scenarios, agents need to exchange information.
-mesa-llm supports agent-to-agent messaging, allowing agents to communicate
+Mesa-LLM supports agent-to-agent messaging, allowing agents to communicate
 explicitly rather than relying on shared state.
 
 In this tutorial:


### PR DESCRIPTION
Previously we added some documentation into ReadtheDocs site through https://github.com/mesa/mesa-llm/pull/64, https://github.com/mesa/mesa-llm/pull/60, and https://github.com/mesa/mesa-llm/pull/45. While some of them are successfully rendered at ReadtheDocs, there's no entry to the page since they are not added into `docs/index.md`. Some other pages are linked to GitHub markdown, not ReadtheDocs itself.

This PR adds entries to these pages in `docs/index.md` and links to their rendered ReadtheDocs pages instead of source markdown at GitHub. The folder structure is also updated to:

```bash
docs/
├── apis/
│   ├── api_main.md
│   ├── ...
│ 
├── examples.md
├── getting_started.md
├── index.md
├── overview.md
└── tutorials/
    ├── first_model.md
    ├── index.md
    └── negotiation_model_tutorial.md
```