### PR TITLE
Fix ShortTermMemory post-step edge cases

### DIFF
--- a/mesa_llm/memory/st_memory.py
+++ b/mesa_llm/memory/st_memory.py
@@ -55,17 +55,21 @@ class ShortTermMemory(Memory):
             self.step_content = {}
             return
 
-        elif not self.short_term_memory[-1].content.get("step", None):
-            pre_step = self.short_term_memory.pop()
-            self.step_content.update(pre_step.content)
-            new_entry = MemoryEntry(
-                agent=self.agent,
-                content=self.step_content,
-                step=self.agent.model.steps,
-            )
+        if not self.short_term_memory or self.short_term_memory[-1].step is not None:
+            return
 
-            self.short_term_memory.append(new_entry)
-            self.step_content = {}
+        pre_step_entry = self.short_term_memory.pop()
+        self.step_content.update(pre_step_entry.content)
+        new_entry = MemoryEntry(
+            agent=self.agent,
+            content=self.step_content,
+            step=self.agent.model.steps,
+        )
+
+        self.short_term_memory.append(new_entry)
+        if len(self.short_term_memory) > self.n:
+            self.short_term_memory.popleft()
+        self.step_content = {}
 
         # Display the new entry
         if self.display:

--- a/tests/test_memory/test_st_memory.py
+++ b/tests/test_memory/test_st_memory.py
@@ -1,0 +1,38 @@
+from mesa_llm.memory.st_memory import ShortTermMemory
+
+
+class TestShortTermMemory:
+    def test_process_step_post_without_prestep_is_noop(self, mock_agent):
+        memory = ShortTermMemory(agent=mock_agent, n=5, display=False)
+
+        memory.process_step(pre_step=False)
+
+        assert len(memory.short_term_memory) == 0
+        assert memory.step_content == {}
+
+    def test_process_step_double_post_is_noop_after_commit(self, mock_agent):
+        memory = ShortTermMemory(agent=mock_agent, n=5, display=False)
+        memory.add_to_memory("observation", {"status": "ready"})
+
+        memory.process_step(pre_step=True)
+        memory.process_step(pre_step=False)
+
+        assert len(memory.short_term_memory) == 1
+        assert memory.short_term_memory[-1].step == mock_agent.model.steps
+
+        # A second post-step call should not crash or mutate committed memory.
+        memory.process_step(pre_step=False)
+        assert len(memory.short_term_memory) == 1
+        assert memory.short_term_memory[-1].step == mock_agent.model.steps
+
+    def test_capacity_limit_keeps_only_recent_entries(self, mock_agent):
+        memory = ShortTermMemory(agent=mock_agent, n=2, display=False)
+
+        for step in range(3):
+            mock_agent.model.steps = step
+            memory.add_to_memory("observation", {"counter": step})
+            memory.process_step(pre_step=True)
+            memory.process_step(pre_step=False)
+
+        assert len(memory.short_term_memory) == 2
+        assert [entry.step for entry in memory.short_term_memory] == [1, 2]


### PR DESCRIPTION
## Summary
- guard `ShortTermMemory.process_step(pre_step=False)` against missing or already-committed pre-step entries so it safely no-ops instead of raising errors
- enforce the configured `n` capacity by evicting the oldest entry after appending a committed step
- add regression tests for post-step edge cases and capacity behavior in `tests/test_memory/test_st_memory.py`

## Test plan
- [x] `. .venv/bin/activate && pytest tests/test_memory/test_st_memory.py tests/test_memory/test_STLT_memory.py -q`
- [x] `. .venv/bin/activate && pytest --cov=mesa_llm tests/`

