### PR TITLE
fix: handle string output from memory in get_react_prompt method

### DIFF
--- a/mesa_llm/reasoning/react.py
+++ b/mesa_llm/reasoning/react.py
@@ -46,7 +46,11 @@ class ReActReasoning(Reasoning):
         return system_prompt
 
     def get_react_prompt(self, obs: Observation) -> list[str]:
-        prompt_list = self.agent.memory.get_prompt_ready()
+        prompt_ready = self.agent.memory.get_prompt_ready()
+        if isinstance(prompt_ready, str):
+            prompt_list = [prompt_ready]
+        else:
+            prompt_list = list(prompt_ready)
         last_communication = self.agent.memory.get_communication_history()
 
         if last_communication:

--- a/tests/test_reasoning/test_react.py
+++ b/tests/test_reasoning/test_react.py
@@ -73,6 +73,21 @@ class TestReActReasoning:
         assert len(prompt_list) >= 1
         assert "last communication" not in prompt_list[-1]
 
+    def test_get_react_prompt_with_string_memory_output(self):
+        """Test get_react_prompt handles string memory output."""
+        mock_agent = Mock()
+        mock_agent.memory = Mock()
+        mock_agent.memory.get_prompt_ready.return_value = "memory1"
+        mock_agent.memory.get_communication_history.return_value = ""
+
+        reasoning = ReActReasoning(mock_agent)
+
+        obs = Observation(step=1, self_state={}, local_state={})
+        prompt_list = reasoning.get_react_prompt(obs)
+
+        assert prompt_list[0] == "memory1"
+        assert "current observation" in prompt_list[-1]
+
     def test_plan_with_prompt(self):
         """Test plan method with custom prompt."""
         mock_agent = Mock()


### PR DESCRIPTION
### Summary
This PR fixes a ReAct memory prompt compatibility bug where ReActReasoning assumed memory context was always list-like.
The bug caused runtime failures with valid memory backends that return a string from `get_prompt_ready()`, reducing backend interchangeability and breaking planning.
### Bug / Issue Closes #113
`ReActReasoning.get_react_prompt()` called `.append(...)` on the value returned by `self.agent.memory.get_prompt_ready()`.
However, the memory interface and several implementations (ShortTermMemory, etc.) return a str, not a list.
Expected:
ReAct should accept memory context from any implementation conforming to the memory interface.
Actual:
Using a string-returning memory backend raises:
`AttributeError: 'str' object has no attribute 'append'`
Implem
### Implementation
Updated `mesa_llm/reasoning/react.py` in `get_react_prompt()`:
Read memory output into prompt_ready.
If prompt_ready is a str, wrap it as [prompt_ready].
Otherwise, convert to list(prompt_ready) and continue.
This preserves existing behavior for list-like memory prompts while adding support for string outputs.
Added regression test in `tests/test_reasoning/test_react.py`:
`test_get_react_prompt_with_string_memory_output`
Verifies string memory output no longer crashes and observation context is appended correctly.

### Testing
Executed:
`./.venv/bin/pytest tests/test_reasoning/test_react.py`
Result:
`11 passed`
Validation covered:
Existing ReAct tests still pass.
New regression case (string memory output) passes.
### Additional Notes
<!-- Add any additional information that may be relevant for the reviewers, such as potential side effects, dependencies, or related work.
