### PR TITLE
Example/Add Rumor Spreading Model Example

### DIFF
--- a/examples/rumor_spreading/Readme.md
+++ b/examples/rumor_spreading/Readme.md
@@ -1,0 +1,208 @@
+# Rumor Spreading Model
+
+**Disclaimer**: This is an original model created for Mesa-LLM. It is inspired by classic information-diffusion and epidemic-spreading research but is not a direct port of any single paper.
+
+## Summary
+
+This model simulates how **misinformation and verified news compete** to shape public belief inside a community. Two journalists sit at fixed positions on the grid and broadcast stories every step — one publishes sensational, potentially fabricated headlines; the other publishes calm, evidence-based facts. Citizens wander around the neighbourhood, bump into each other, hear what the journalists broadcast, and decide — based on who they are as people — whether to **believe it, doubt it, debunk it, or simply pass it on**.
+
+The central question the model asks:
+
+> *Does misinformation cascade through a community, or do skeptics and critical thinkers slow it down — and how does the mix of personalities in the population determine the outcome?*
+
+This is a question you cannot answer with a simple probability rule. The answer depends on the **content** of the message and the **character** of the person receiving it — exactly the kind of nuanced, language-level reasoning that makes LLM-powered agents the right tool here.
+
+---
+
+## Agents
+
+### `CitizenAgent`
+
+Ordinary people who move around the grid, hear stories, and form opinions.
+
+Every citizen has a **personality** that shapes how they reason about information:
+
+| Personality | Behaviour |
+|---|---|
+| `credulous` | Trusts almost anything they hear; spreads quickly without much evaluation. |
+| `skeptic` | Questions claims before accepting them; often stays on the fence. |
+| `critical_thinker` | Demands logic and evidence; most likely to debunk misinformation. |
+| `conformist` | Follows the crowd; goes along with whatever most neighbours already believe. |
+
+Citizens are distributed round-robin across personalities so every run starts with a natural mix.
+
+Each citizen tracks a **`BeliefState`**:
+
+| State | Meaning |
+|---|---|
+| `UNINFORMED` | Hasn't heard anything meaningful yet. |
+| `BELIEVER` | Has accepted the rumor and is willing to spread it. |
+| `SKEPTIC` | Heard something, doubts it, but hasn't proven it false. |
+| `DEBUNKED` | Is confident the story is false and will say so if asked. |
+
+---
+
+### `JournalistAgent`
+
+Journalists sit at **fixed positions** on the grid and never move. Their only job is to publish stories every single step. There are two of them placed in opposite corners:
+
+| Journalist | Bias | Behaviour |
+|---|---|---|
+| Journalist 1 | `biased` | Publishes sensational, emotionally charged, sometimes fabricated stories. Sets `is_misinformation=True`. |
+| Journalist 2 | `objective` | Publishes verified, factual, calm news. Sets `is_misinformation=False`. |
+
+Their stories are broadcast directly into the memory of every citizen within their `vision` radius — those citizens will read and reason about the story on their next turn.
+
+---
+
+## Tools
+
+| Tool | Used by | What it does |
+|---|---|---|
+| `update_belief` | `CitizenAgent` | Records the citizen's personal stance: `BELIEVER`, `SKEPTIC`, or `DEBUNKED`. |
+| `publish_story` | `JournalistAgent` | Writes a headline and broadcasts it to all nearby citizens' memories. Tags it as `[MISINFORMATION]` or `[VERIFIED NEWS]`. |
+| `speak_to` | `CitizenAgent` | Sends a message to one or more nearby citizens to spread what they believe. |
+| `move_one_step` | `CitizenAgent` | Moves one cell in any cardinal or diagonal direction to explore the grid. |
+
+---
+
+## How Information Flows (Step by Step)
+
+```
+Step N (with current defaults: 12 citizens, 2 journalists, 8×8 grid, vision=2):
+
+  1. Journalist (biased)   → publishes "[MISINFORMATION] Shocking scandal uncovered!"
+                              → drops into memory of every citizen within vision=2
+
+  2. Journalist (objective) → publishes "[VERIFIED NEWS] New park opens downtown."
+                              → drops into memory of every citizen within vision=2
+
+  3. Citizens take turns (shuffled):
+       - Each citizen reads its short-term memory (recent messages received)
+       - Counts how many neighbours are already believers (social pressure)
+       - Builds a reasoning prompt with: personality + heard rumor + social context
+       - LLM reasons (ReActReasoning by default) → calls tools:
+           → credulous citizen: speak_to(neighbours, "Did you hear? Scandal!") + update_belief("BELIEVER")
+           → skeptic citizen:   update_belief("SKEPTIC")
+           → critical_thinker:  update_belief("DEBUNKED") + speak_to(neighbours, "That's false.")
+           → conformist:        looks at neighbour count → follows majority
+       - If nothing heard yet: move_one_step("North") to explore
+
+  4. DataCollector records counts of each BeliefState.
+```
+
+---
+
+## What Makes LLM Genuinely Useful Here
+
+In a classical rule-based epidemic model (like SIR), spread is a coin flip: `if random() < spread_chance: infect()`. The content of the rumor is irrelevant.
+
+Here, the LLM actually **reads the headline**. A `critical_thinker` receiving `"[MISINFORMATION] Government hiding alien contact"` will reason about the claim itself — recognise the sensational framing, weigh it against what it knows, and likely call `update_belief("DEBUNKED")`. Give that same agent `"[VERIFIED NEWS] City council approves budget"` and they'll accept it calmly.
+
+This means the **quality of the story matters**, the **framing matters**, and the **personality of the recipient matters** — none of which a probability-based rule could capture.
+
+---
+
+## Data Collection
+
+The model tracks the following metrics every step:
+
+| Metric | Description |
+|---|---|
+| `Uninformed` | Citizens who haven't formed a belief yet. |
+| `Believers` | Citizens who accepted the rumor. |
+| `Skeptics` | Citizens who doubt but haven't debunked. |
+| `Debunked` | Citizens actively calling the story false. |
+| `Stories_Published` | Total stories published by all journalists so far. |
+
+The Solara chart shows all four belief curves over time — you can watch the cascade or the resistance unfold live.
+
+---
+
+## Visual Guide (Grid)
+
+| Symbol | Colour | Meaning |
+|---|---|---|
+| ● blue `#648FFF` | Uninformed citizen |
+| ● orange `#FE6100` | Believer citizen |
+| ● amber `#FFB000` | Skeptic citizen |
+| ● pink `#DC267F` | Debunked citizen |
+| ● red `#FF0000` | Journalist (fixed, never moves) |
+
+---
+
+## Configuration
+
+### Default Parameters (in `app.py`)
+
+| Parameter | Default | Purpose |
+|---|---|---|
+| `initial_citizens` | 12 | Number of citizen agents; more = richer dynamics. |
+| `initial_journalists` | 2 | Number of journalists (max 2, opposite corners). |
+| `width` / `height` | 8 | Grid size; larger = more room to wander. |
+| `vision` | 2 | Broadcast and observation radius (cells). |
+| `reasoning` | `ReActReasoning` | LLM reasoning strategy; switch to `CoTReasoning` for fewer LLM calls. |
+| `llm_model` | `ollama/llama3.1:8b` | Change to `openai/gpt-4o-mini`, etc. |
+| `api_base` | (Remote Ollama URL) | Set to your Ollama server; omit for local/default. |
+
+### Tuning for Performance
+
+**Fewer LLM calls:**
+- Reduce `initial_citizens` (e.g., 6 instead of 12)
+- Reduce `vision` (e.g., 1 instead of 2)
+- Switch `reasoning` to `CoTReasoning` (1 call/agent vs 3–5 for ReAct)
+
+**Richer dynamics:**
+- Increase `initial_citizens` (e.g., 20)
+- Increase grid size (`width`, `height`)
+- Increase `vision` for faster information spread
+
+If you have cloned the repo into your local machine, ensure you run the following command from the root of the library: ``pip install -e .``. Then, you will need an API key from an LLM provider of your choice. Once you have obtained the API key, follow the steps below to set it up for this model.
+
+### Option 1: Local LLM (Ollama)
+
+If running Ollama on your **local machine**:
+1. Start Ollama: `ollama serve` (default: `http://localhost:11434`)
+2. Pull a model: `ollama pull llama3.1:8b`
+3. Run the example: `solara run examples/rumor_spreading/app.py`
+
+If running Ollama on a **remote machine**:
+1. Edit `app.py`: set `OLLAMA_URL = "http://your-remote-machine:port"` (e.g., the pinggy URL you received)
+2. Run the example from your local machine: `solara run examples/rumor_spreading/app.py`
+
+### Option 2: Cloud LLM (OpenAI, Gemini, etc.)
+
+1. Ensure the `dotenv` package is installed. If not, run ``pip install python-dotenv``.
+2. In the root folder of the project, create a file named `.env`.
+3. If you are using OpenAI's API key, add: ``OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxx``. If you are using Gemini, add: ``GEMINI_API_KEY=your-gemini-api-key-here``.
+4. In `app.py`, change:
+   - `llm_model` to match your provider: e.g. `"openai/gpt-4o-mini"` or `"gemini/gemini-1.5-flash"`
+   - `OLLAMA_URL` can be removed or left as-is (it won't be used)
+
+Once set up, run from the **root of the repository**:
+
+```bash
+solara run examples/rumor_spreading/app.py
+```
+
+---
+
+## Files
+
+* `model.py` — Core model logic: grid setup, agent creation, step ordering, data collection.
+* `agents.py` — `CitizenAgent` and `JournalistAgent` classes with `BeliefState` enum.
+* `tools.py` — Custom tools: `update_belief` (citizen) and `publish_story` (journalist).
+* `app.py` — Solara interactive visualization: grid display and live belief-state chart.
+* `__init__.py` — Registers tools at import time.
+
+---
+
+
+This model draws conceptual inspiration from:
+
+- **SIR / SEIR epidemic models** — the canonical framework for information-spreading simulations.
+- Vosoughi, S., Roy, D., & Aral, S. (2018). *The spread of true and false news online*. **Science**, 359(6380), 1146–1151. — Empirical study showing false news spreads faster than true news on Twitter.
+- Generative Agents: Interactive Simulacra of Human Behavior (Park et al., 2023) — the foundation for LLM-powered agent memory and reasoning used in Mesa-LLM.
+
+Mesa's original epidemic-spreading example (without LLMs) can be found here:
+https://github.com/mesa/mesa/tree/main/mesa/examples/basic/virus_on_network

--- a/examples/rumor_spreading/__init__.py
+++ b/examples/rumor_spreading/__init__.py
@@ -1,0 +1,1 @@
+import examples.rumor_spreading.tools  # noqa: F401, to register tools

--- a/examples/rumor_spreading/agents.py
+++ b/examples/rumor_spreading/agents.py
@@ -1,0 +1,298 @@
+import contextlib
+from enum import Enum
+
+import mesa
+
+from mesa_llm.llm_agent import LLMAgent
+from mesa_llm.memory.st_lt_memory import STLTMemory
+from mesa_llm.module_llm import ModuleLLM
+from mesa_llm.tools.tool_manager import ToolManager
+
+# Each agent type gets its own tool manager.
+# Inbuilt tools (move_one_step, speak_to, teleport_to_location) are automatically
+# included because mesa_llm.__init__ registers them before any ToolManager is created.
+citizen_tool_manager = ToolManager()
+journalist_tool_manager = ToolManager()
+
+
+class BeliefState(Enum):
+    UNINFORMED = "uninformed"
+    BELIEVER = "believer"
+    SKEPTIC = "skeptic"
+    DEBUNKED = "debunked"
+
+
+class CitizenAgent(LLMAgent, mesa.discrete_space.CellAgent):
+    """
+    An ordinary person living in the community.
+
+    They wander around, bump into neighbors, and hear things — from journalists,
+    from friends, from strangers. Whether they believe what they hear depends
+    entirely on who they are as a person.
+
+    Personality options:
+        - credulous:        Tends to believe and repeat almost anything they hear.
+        - skeptic:          Doubts first, asks questions, rarely spreads unverified info.
+        - critical_thinker: Evaluates claims carefully; needs logic and evidence to believe.
+        - conformist:       Goes along with whatever the majority around them believes.
+    """
+
+    def __init__(
+        self,
+        model,
+        reasoning,
+        llm_model,
+        system_prompt,
+        vision,
+        internal_state,
+        step_prompt,
+        personality: str = "credulous",
+        api_base: str | None = None,
+    ):
+        super().__init__(
+            model=model,
+            reasoning=reasoning,
+            llm_model=llm_model,
+            system_prompt=system_prompt,
+            vision=vision,
+            internal_state=internal_state,
+            step_prompt=step_prompt,
+        )
+
+        self.personality = personality
+        self.belief_state = BeliefState.UNINFORMED
+
+        # Override the LLM to ensure it hits the configured api_base
+        self.llm = ModuleLLM(llm_model=llm_model, api_base=api_base)
+
+        self.memory = STLTMemory(
+            agent=self,
+            display=True,
+            llm_model=llm_model,
+            consolidation_capacity=100,  # never consolidate — no extra LLM calls
+        )
+
+        # Ensure memory LLM hits same remote endpoint when provided
+        if api_base:
+            with contextlib.suppress(Exception):
+                self.memory.llm.api_base = api_base
+
+        # Attach the citizen-specific tool manager so tools like
+        # `update_belief` and `speak_to` are available to the agent.
+        self.tool_manager = citizen_tool_manager
+
+        self.internal_state.append(f"My personality is: {self.personality}")
+        self.internal_state.append(
+            f"My current belief state is: {self.belief_state.value}"
+        )
+
+    # Helpers
+    def _sync_belief_in_internal_state(self):
+        """Keep the internal_state belief line in sync with self.belief_state."""
+        self.internal_state = [
+            s for s in self.internal_state if "belief state" not in s.lower()
+        ]
+        self.internal_state.append(
+            f"My current belief state is: {self.belief_state.value}"
+        )
+
+    def _get_recent_rumors(self) -> str:
+        """
+        Dig through short-term memory and pull out any messages that were
+        sent to this agent — those are the rumors worth thinking about.
+        """
+        rumors = []
+
+        if hasattr(self.memory, "short_term_memory"):
+            # Read the last 8 entries and pick out messages
+            for entry in list(self.memory.short_term_memory)[-8:]:
+                if isinstance(entry.content, dict) and "message" in entry.content:
+                    sender_id = entry.content.get("sender", "Unknown")
+                    msg = entry.content.get("message", "")
+                    rumors.append(f'  - From Agent {sender_id}: "{msg}"')
+
+        return "\n".join(rumors) if rumors else "  (nothing yet)"
+
+    def _count_believers_nearby(self) -> int:
+        """How many neighbors in radius-1 are already believers?"""
+        return sum(
+            1
+            for a in self.model.grid.get_neighbors(
+                self.pos, moore=True, include_center=False, radius=1
+            )
+            if isinstance(a, CitizenAgent) and a.belief_state == BeliefState.BELIEVER
+        )
+
+    def _get_nearby_citizen_ids(self) -> list[int]:
+        """IDs of all citizens within vision that could receive a message."""
+        return [
+            a.unique_id
+            for a in self.model.grid.get_neighbors(
+                self.pos, moore=True, include_center=False, radius=self.vision
+            )
+            if isinstance(a, CitizenAgent)
+        ]
+
+    # Step
+    def _build_step_prompt(self) -> str:
+        recent_rumors = self._get_recent_rumors()
+        believers_nearby = self._count_believers_nearby()
+        nearby_citizen_ids = self._get_nearby_citizen_ids()
+
+        return (
+            f"RUMORS HEARD:\n{recent_rumors}\n"
+            f"BELIEVERS NEARBY: {believers_nearby} | "
+            f"CITIZENS YOU CAN TALK TO: {nearby_citizen_ids}\n"
+            f"YOUR PERSONALITY: {self.personality} | "
+            f"YOUR BELIEF: {self.belief_state.value}\n\n"
+            "Pick ONE action:\n"
+            "  - Heard something + believe it → speak_to neighbours, then update_belief BELIEVER\n"
+            "  - Doubt it → update_belief SKEPTIC\n"
+            "  - Sure it is false → update_belief DEBUNKED\n"
+            "  - Nothing heard → move_one_step to explore\n"
+        )
+
+    def step(self):
+        self._sync_belief_in_internal_state()
+        observation = self.generate_obs()
+        prompt = self._build_step_prompt()
+
+        plan = self.reasoning.plan(
+            prompt=prompt,
+            obs=observation,
+            selected_tools=["update_belief", "speak_to", "move_one_step"],
+        )
+        self.apply_plan(plan)
+
+    async def astep(self):
+        self._sync_belief_in_internal_state()
+        observation = self.generate_obs()
+        prompt = self._build_step_prompt()
+
+        plan = await self.reasoning.aplan(
+            prompt=prompt,
+            obs=observation,
+            selected_tools=["update_belief", "speak_to", "move_one_step"],
+        )
+        self.apply_plan(plan)
+
+
+class JournalistAgent(LLMAgent, mesa.discrete_space.CellAgent):
+    """
+    A journalist sitting at a fixed desk, broadcasting stories to the public.
+
+    They never move — their job is to publish. What they publish, and how
+    honestly, depends on whether they're biased or objective.
+
+    Bias options:
+        - biased:    Sensational, emotionally charged, sometimes misleading.
+        - objective: Factual, measured, evidence-based.
+    """
+
+    def __init__(
+        self,
+        model,
+        reasoning,
+        llm_model,
+        system_prompt,
+        vision,
+        internal_state,
+        step_prompt,
+        bias: str = "objective",
+        api_base: str | None = None,
+    ):
+        super().__init__(
+            model=model,
+            reasoning=reasoning,
+            llm_model=llm_model,
+            system_prompt=system_prompt,
+            vision=vision,
+            internal_state=internal_state,
+            step_prompt=step_prompt,
+        )
+
+        self.bias = bias
+        self.stories_published = 0
+
+        # Override the LLM to ensure it hits the configured api_base
+        self.llm = ModuleLLM(llm_model=llm_model, api_base=api_base)
+
+        self.memory = STLTMemory(
+            agent=self,
+            display=True,
+            llm_model=llm_model,
+            consolidation_capacity=100,  # never consolidate — no extra LLM calls
+        )
+
+        if api_base:
+            with contextlib.suppress(Exception):
+                self.memory.llm.api_base = api_base
+
+        # Attach the journalist-specific tool manager so `publish_story`
+        # is available to this agent.
+        self.tool_manager = journalist_tool_manager
+
+        self.internal_state.append(f"I am a {self.bias} journalist.")
+        self.internal_state.append(
+            f"Total stories I have published so far: {self.stories_published}"
+        )
+
+    # Helpers
+
+    def _sync_stories_in_internal_state(self):
+        self.internal_state = [
+            s
+            for s in self.internal_state
+            if "stories i have published" not in s.lower()
+        ]
+        self.internal_state.append(
+            f"Total stories I have published so far: {self.stories_published}"
+        )
+
+    def _get_nearby_citizen_ids(self) -> list[int]:
+        return [
+            a.unique_id
+            for a in self.model.grid.get_neighbors(
+                self.pos, moore=True, include_center=False, radius=self.vision
+            )
+            if isinstance(a, CitizenAgent)
+        ]
+
+    # ------------------------------------------------------------------
+    # Step
+    # ------------------------------------------------------------------
+
+    def _build_step_prompt(self) -> str:
+        nearby_ids = self._get_nearby_citizen_ids()
+
+        return (
+            f"CITIZENS IN RANGE: {nearby_ids}\n"
+            f"YOUR BIAS: {self.bias}\n\n"
+            "Use publish_story. "
+            "If biased: write a sensational or misleading headline, set is_misinformation=True. "
+            "If objective: write a factual headline, set is_misinformation=False."
+        )
+
+    def step(self):
+        self._sync_stories_in_internal_state()
+        observation = self.generate_obs()
+        prompt = self._build_step_prompt()
+
+        plan = self.reasoning.plan(
+            prompt=prompt,
+            obs=observation,
+            selected_tools=["publish_story"],
+        )
+        self.apply_plan(plan)
+
+    async def astep(self):
+        self._sync_stories_in_internal_state()
+        observation = self.generate_obs()
+        prompt = self._build_step_prompt()
+
+        plan = await self.reasoning.aplan(
+            prompt=prompt,
+            obs=observation,
+            selected_tools=["publish_story"],
+        )
+        self.apply_plan(plan)

--- a/examples/rumor_spreading/app.py
+++ b/examples/rumor_spreading/app.py
@@ -1,0 +1,169 @@
+# app.py
+import logging
+import warnings
+
+from dotenv import load_dotenv
+from mesa.visualization import (
+    SolaraViz,
+    make_plot_component,
+    make_space_component,
+)
+from mesa.visualization.components import AgentPortrayalStyle
+
+from examples.rumor_spreading.agents import BeliefState, CitizenAgent, JournalistAgent
+from examples.rumor_spreading.model import RumorSpreadingModel
+from mesa_llm.parallel_stepping import enable_automatic_parallel_stepping
+from mesa_llm.reasoning.react import ReActReasoning
+
+# Suppress Pydantic serialization warnings
+warnings.filterwarnings(
+    "ignore",
+    category=UserWarning,
+    module="pydantic.main",
+    message=r".*Pydantic serializer warnings.*",
+)
+
+logging.getLogger("pydantic").setLevel(logging.ERROR)
+
+enable_automatic_parallel_stepping(mode="threading")
+
+load_dotenv()
+
+# Visual identity — each belief state gets a distinct colour so you
+# can see the cascade happening in real time on the grid.
+BELIEF_COLORS = {
+    BeliefState.UNINFORMED: "#648FFF",  # calm blue   — hasn't heard anything yet
+    BeliefState.BELIEVER: "#FE6100",  # orange      — bought into it
+    BeliefState.SKEPTIC: "#FFB000",  # amber       — doubtful, on the fence
+    BeliefState.DEBUNKED: "#DC267F",  # pink/red    — actively calling it false
+}
+JOURNALIST_COLOR = "#FF0000"  # bright red — unmistakably visible
+
+# Model parameters exposed to the Solara UI
+OLLAMA_URL = "http://uutjx-34-50-185-200.a.free.pinggy.link"
+
+model_params = {
+    "seed": {
+        "type": "InputText",
+        "value": 42,
+        "label": "Random Seed",
+    },
+    # Increased counts/area for clearer dynamics
+    "initial_citizens": 12,
+    "initial_journalists": 2,
+    "width": 8,
+    "height": 8,
+    "reasoning": ReActReasoning,
+    "llm_model": "ollama/llama3.1:8b",
+    "vision": 2,  # slightly larger broadcast radius
+    "parallel_stepping": False,
+    "api_base": OLLAMA_URL,
+}
+
+model = RumorSpreadingModel(
+    initial_citizens=model_params["initial_citizens"],
+    initial_journalists=model_params["initial_journalists"],
+    width=model_params["width"],
+    height=model_params["height"],
+    reasoning=model_params["reasoning"],
+    llm_model=model_params["llm_model"],
+    vision=model_params["vision"],
+    seed=model_params["seed"]["value"],
+    parallel_stepping=model_params["parallel_stepping"],
+    api_base=model_params["api_base"],
+)
+
+
+# Agent portrayal — what each dot on the grid looks like
+def agent_portrayal(agent):
+    if agent is None:
+        return
+
+    if isinstance(agent, JournalistAgent):
+        # Large red circle — unmissable on any background
+        return AgentPortrayalStyle(color=JOURNALIST_COLOR, size=150, alpha=1.0)
+
+    if isinstance(agent, CitizenAgent):
+        return AgentPortrayalStyle(
+            color=BELIEF_COLORS[agent.belief_state],
+            size=50,
+            alpha=0.9,
+        )
+
+
+def post_process(ax):
+    ax.set_aspect("equal")
+    ax.set_xticks([])
+    ax.set_yticks([])
+    ax.get_figure().set_size_inches(10, 10)
+
+    # Hand-drawn legend at the bottom of the plot
+    legend_y = -0.9
+    ax.text(
+        0,
+        legend_y,
+        "● Uninformed",
+        color=BELIEF_COLORS[BeliefState.UNINFORMED],
+        fontsize=9,
+        fontweight="bold",
+    )
+    ax.text(
+        2.5,
+        legend_y,
+        "● Believer",
+        color=BELIEF_COLORS[BeliefState.BELIEVER],
+        fontsize=9,
+        fontweight="bold",
+    )
+    ax.text(
+        5,
+        legend_y,
+        "● Skeptic",
+        color=BELIEF_COLORS[BeliefState.SKEPTIC],
+        fontsize=9,
+        fontweight="bold",
+    )
+    ax.text(
+        7.5,
+        legend_y,
+        "● Debunked",
+        color=BELIEF_COLORS[BeliefState.DEBUNKED],
+        fontsize=9,
+        fontweight="bold",
+    )
+    ax.text(
+        0,
+        legend_y - 0.6,
+        "● Journalist (fixed)",
+        color=JOURNALIST_COLOR,
+        fontsize=9,
+        fontweight="bold",
+    )
+
+
+# Solara components
+space_component = make_space_component(
+    agent_portrayal, post_process=post_process, draw_grid=False
+)
+
+chart_component = make_plot_component(
+    {
+        "Uninformed": BELIEF_COLORS[BeliefState.UNINFORMED],
+        "Believers": BELIEF_COLORS[BeliefState.BELIEVER],
+        "Skeptics": BELIEF_COLORS[BeliefState.SKEPTIC],
+        "Debunked": BELIEF_COLORS[BeliefState.DEBUNKED],
+    }
+)
+
+if __name__ == "__main__":
+    page = SolaraViz(
+        model,
+        components=[space_component, chart_component],
+        model_params=model_params,
+        name="Rumor Spreading Model",
+    )
+
+"""
+run with:
+    solara run examples/rumor_spreading/app.py
+"""

--- a/examples/rumor_spreading/app.py
+++ b/examples/rumor_spreading/app.py
@@ -40,7 +40,7 @@ BELIEF_COLORS = {
 JOURNALIST_COLOR = "#FF0000"  # bright red — unmistakably visible
 
 # Model parameters exposed to the Solara UI
-OLLAMA_URL = "http://uutjx-34-50-185-200.a.free.pinggy.link"
+OLLAMA_URL = "put_your_ollama_url_here"  # e.g. "http://localhost:11434"
 
 model_params = {
     "seed": {

--- a/examples/rumor_spreading/model.py
+++ b/examples/rumor_spreading/model.py
@@ -1,0 +1,219 @@
+from mesa.datacollection import DataCollector
+from mesa.model import Model
+from mesa.space import MultiGrid
+from rich import print
+
+from examples.rumor_spreading.agents import BeliefState, CitizenAgent, JournalistAgent
+from mesa_llm.reasoning.reasoning import Reasoning
+from mesa_llm.recording.record_model import record_model
+
+# Personality pool — citizens are created round-robin from this list
+# so every run gets a natural mix of personality types.
+_PERSONALITIES = ["credulous", "skeptic", "critical_thinker", "conformist"]
+
+# Two journalists, one on each side of the grid. Biases differ so their
+# stories compete — biased journalist vs. objective journalist.
+_JOURNALIST_SETUPS = [
+    {"bias": "biased", "position_fn": lambda w, h: (w // 4, h // 4)},
+    {"bias": "objective", "position_fn": lambda w, h: (3 * w // 4, 3 * h // 4)},
+]
+
+
+@record_model(output_dir="recordings")
+class RumorSpreadingModel(Model):
+    """
+    A model where journalists publish stories and citizens decide whether
+    to believe, spread, doubt, or debunk what they hear.
+
+    The interesting tension:
+        - A biased journalist seeds misinformation from one corner.
+        - An objective journalist publishes verified news from another.
+        - Citizens with different personalities process information differently.
+        - Believers spread via speak_to; skeptics and critical thinkers push back.
+
+    Watch the chart: will misinformation cascade, or will skeptics slow it down?
+
+    Args:
+        initial_citizens:    How many citizens to populate the grid with.
+        initial_journalists: How many journalists to place (max 2, one per corner).
+        width:               Grid width.
+        height:              Grid height.
+        reasoning:           Reasoning class (e.g. ReActReasoning).
+        llm_model:           LLM backend string, e.g. "openai/gpt-4o-mini".
+        vision:              How many cells an agent can see in every direction.
+        parallel_stepping:   Run agent steps concurrently (faster but needs threading).
+        seed:                Random seed for reproducibility.
+    """
+
+    def __init__(
+        self,
+        initial_citizens: int,
+        initial_journalists: int,
+        width: int,
+        height: int,
+        reasoning: type[Reasoning],
+        llm_model: str,
+        vision: int,
+        parallel_stepping: bool = True,
+        seed=None,
+        api_base: str | None = None,
+    ):
+        super().__init__(seed=seed)
+
+        # Remote LLM endpoint (e.g. remote Ollama URL)
+        self.api_base = api_base
+
+        self.width = width
+        self.height = height
+        self.parallel_stepping = parallel_stepping
+        self.grid = MultiGrid(self.width, self.height, torus=False)
+
+        # Data collection — the chart will show how belief spreads over time
+        model_reporters = {
+            "Uninformed": lambda m: sum(
+                1
+                for a in m.agents
+                if isinstance(a, CitizenAgent)
+                and a.belief_state == BeliefState.UNINFORMED
+            ),
+            "Believers": lambda m: sum(
+                1
+                for a in m.agents
+                if isinstance(a, CitizenAgent)
+                and a.belief_state == BeliefState.BELIEVER
+            ),
+            "Skeptics": lambda m: sum(
+                1
+                for a in m.agents
+                if isinstance(a, CitizenAgent) and a.belief_state == BeliefState.SKEPTIC
+            ),
+            "Debunked": lambda m: sum(
+                1
+                for a in m.agents
+                if isinstance(a, CitizenAgent)
+                and a.belief_state == BeliefState.DEBUNKED
+            ),
+            "Stories_Published": lambda m: sum(
+                a.stories_published for a in m.agents if isinstance(a, JournalistAgent)
+            ),
+        }
+
+        agent_reporters = {
+            "belief_state": lambda a: getattr(a, "belief_state", None),
+            "personality": lambda a: getattr(a, "personality", None),
+        }
+
+        self.datacollector = DataCollector(
+            model_reporters=model_reporters,
+            agent_reporters=agent_reporters,
+        )
+
+        # ------------------------------------------------------------------
+        # Citizens — scattered across the grid with varied personalities.
+        # Citizens are placed FIRST so that journalists, placed afterwards,
+        # are always the last entry in any shared cell. Mesa's coord_iter()
+        # renders agents in insertion order, so journalists (placed last)
+        # are drawn on top and never hidden by citizen dots.
+        # ------------------------------------------------------------------
+        citizen_system_prompt = (
+            "You are a person living in a community. "
+            "You move around the neighbourhood, talk to people, and hear stories. "
+            "How you react to information depends on who you are — your personality. "
+            "You have three tools: move_one_step to explore, speak_to to share what "
+            "you heard, and update_belief to record your personal stance on a rumor."
+        )
+
+        # Collect journalist positions upfront so we can keep citizens away
+        # from those cells entirely — avoids overlap in the first place.
+        n_journalists = min(initial_journalists, len(_JOURNALIST_SETUPS))
+        journalist_positions = {
+            setup["position_fn"](self.width, self.height)
+            for setup in _JOURNALIST_SETUPS[:n_journalists]
+        }
+
+        placed = 0
+        attempts = 0
+        max_attempts = initial_citizens * 20
+        while placed < initial_citizens and attempts < max_attempts:
+            attempts += 1
+            x = int(self.rng.integers(0, self.width))
+            y = int(self.rng.integers(0, self.height))
+            # Keep journalist cells clear AND avoid stacking citizens on the same cell
+            if (x, y) in journalist_positions or not self.grid.is_cell_empty((x, y)):
+                continue
+
+            personality = _PERSONALITIES[placed % len(_PERSONALITIES)]
+            citizen = CitizenAgent(
+                model=self,
+                reasoning=reasoning,
+                llm_model=llm_model,
+                system_prompt=citizen_system_prompt,
+                vision=vision,
+                internal_state=[],
+                step_prompt="Think about what you've heard. Believe it, question it, or debunk it.",
+                personality=personality,
+                api_base=api_base,
+            )
+            self.grid.place_agent(citizen, (x, y))
+            placed += 1
+
+        # Journalists — placed LAST so they render on top of any co-located
+        # agent when Mesa's visualization iterates the cell list in order.
+        for setup in _JOURNALIST_SETUPS[:n_journalists]:
+            bias = setup["bias"]
+            pos = setup["position_fn"](self.width, self.height)
+
+            system_prompt = (
+                f"You are a {bias} journalist working for a local news outlet. "
+                "You sit at your desk and publish stories to inform — or mislead — "
+                "the community around you. Use publish_story every single turn."
+            )
+
+            journalist = JournalistAgent(
+                model=self,
+                reasoning=reasoning,
+                llm_model=llm_model,
+                system_prompt=system_prompt,
+                vision=vision,
+                internal_state=[],
+                step_prompt="Write and publish a news story about something happening in the community.",
+                bias=bias,
+                api_base=api_base,
+            )
+            self.grid.place_agent(journalist, pos)
+
+        # Collect initial state (Step 0: all citizens uninformed, no stories published yet)
+        self.datacollector.collect(self)
+
+    # Model step
+
+    def step(self):
+        print(
+            f"\n[bold purple] step  {self.steps} "
+            "────────────────────────────────────────────────────────────────"
+            "[/bold purple]"
+        )
+
+        # Journalists go first so their stories land in citizen memory
+        # before citizens decide what to do this turn.
+        journalists = [a for a in self.agents if isinstance(a, JournalistAgent)]
+        citizens = [a for a in self.agents if isinstance(a, CitizenAgent)]
+
+        for journalist in journalists:
+            try:
+                journalist.step()
+            except Exception as e:
+                print(
+                    f"[yellow]  Journalist {journalist.unique_id} step failed: {e}[/yellow]"
+                )
+
+        self.random.shuffle(citizens)
+        for citizen in citizens:
+            try:
+                citizen.step()
+            except Exception as e:
+                print(
+                    f"[yellow]  Citizen {citizen.unique_id} step failed: {e}[/yellow]"
+                )
+
+        self.datacollector.collect(self)

--- a/examples/rumor_spreading/tools.py
+++ b/examples/rumor_spreading/tools.py
@@ -1,0 +1,97 @@
+from typing import TYPE_CHECKING
+
+from examples.rumor_spreading.agents import (
+    BeliefState,
+    CitizenAgent,
+    citizen_tool_manager,
+    journalist_tool_manager,
+)
+from mesa_llm.tools.tool_decorator import tool
+
+if TYPE_CHECKING:
+    from mesa_llm.llm_agent import LLMAgent
+
+
+@tool(tool_manager=citizen_tool_manager)
+def update_belief(agent: "LLMAgent", new_state: str) -> str:
+    """
+    Update the citizen's personal belief about the rumor they have heard.
+
+    Use this after deciding whether you believe, doubt, or want to debunk
+    what you've been told. This is how you record your stance.
+
+        Args:
+            new_state: Your new belief. Must be exactly one of:
+                "BELIEVER"  — you believe the rumor and are willing to spread it.
+                "SKEPTIC"   — you doubt it but haven't proven it false.
+                "DEBUNKED"  — you are confident it is misinformation.
+            agent: Provided automatically.
+
+        Returns:
+            A confirmation string describing the state change.
+    """
+    valid_states = {
+        "BELIEVER": BeliefState.BELIEVER,
+        "SKEPTIC": BeliefState.SKEPTIC,
+        "DEBUNKED": BeliefState.DEBUNKED,
+    }
+
+    if new_state not in valid_states:
+        raise ValueError(
+            f"Invalid state: '{new_state}'. Choose one of {list(valid_states.keys())}."
+        )
+
+    previous = agent.belief_state.value
+    agent.belief_state = valid_states[new_state]
+
+    return (
+        f"Agent {agent.unique_id} ({agent.personality}) changed belief: "
+        f"{previous} → {new_state.lower()}."
+    )
+
+
+@tool(tool_manager=journalist_tool_manager)
+def publish_story(agent: "LLMAgent", headline: str, is_misinformation: bool) -> str:
+    """
+    Broadcast a news story to every citizen within the journalist's vision range.
+
+    The story lands directly in each citizen's memory as a received message,
+    where they can read and reason about it on their next turn.
+
+        Args:
+            headline: The headline or story content to publish. Be specific and realistic.
+            is_misinformation: Set True if the story is fabricated, exaggerated, or misleading.
+                               Set False if it is factual and verified.
+            agent: Provided automatically.
+
+        Returns:
+            A summary of the broadcast — what was published and how many people received it.
+    """
+    nearby_citizens = [
+        a
+        for a in agent.model.grid.get_neighbors(
+            agent.pos, moore=True, include_center=False, radius=agent.vision
+        )
+        if isinstance(a, CitizenAgent)
+    ]
+
+    tag = "[MISINFORMATION]" if is_misinformation else "[VERIFIED NEWS]"
+    full_message = f"{tag} {headline}"
+
+    for citizen in nearby_citizens:
+        citizen.memory.add_to_memory(
+            type="message",
+            content={
+                "message": full_message,
+                "sender": agent.unique_id,
+                "recipients": [c.unique_id for c in nearby_citizens],
+            },
+        )
+
+    agent.stories_published += 1
+
+    return (
+        f"Journalist {agent.unique_id} ({agent.bias}) published: '{full_message}'. "
+        f"Reached {len(nearby_citizens)} citizen(s). "
+        f"Total stories this journalist has published: {agent.stories_published}."
+    )


### PR DESCRIPTION
### Summary

Adds a new LLM-powered agent-based example  **Rumor Spreading**  to the examples directory. The model simulates how misinformation and verified news compete to shape public belief inside a community. Two journalists broadcast stories from fixed positions on the grid; citizens wander, hear stories, and decide  based on their personality  whether to believe, doubt, debunk, or spread what they hear.

---

### Motive

While exploring the [mesa-examples](https://github.com/projectmesa/mesa-examples) repo I noticed all the classic examples (Schelling, Boltzmann, Wolf-Sheep…) are rule-based an agent believes a rumor with probability `p`, full stop. That works fine for aggregate dynamics but it completley misses the *content* of the message and the *character* of the person receiving it.

The question this model is really asking is:

> *Does misinformation cascade through a community, or do skeptics and critical thinkers slow it down?*

You can't answer that with a fixed probability. The answer depends on what the headline actually says and who is reading it exactly the kind of nuanced, language-level reasoning that makes LLM agents the right tool. That gap is what motivated this example.

---

### Implementation

**File structure**
```
examples/rumor_spreading/
├── __init__.py
├── agents.py      # CitizenAgent, JournalistAgent, BeliefState
├── app.py         # Solara visualisation + model_params
├── model.py       # RumorSpreadingModel
├── tools.py       # publish_story, update_belief (custom tools)
└── Readme.md
```

**Agents**

| Agent | Role |
|---|---|
| `CitizenAgent` | Moves around the grid, hears stories, updates `BeliefState` via LLM reasoning |
| `JournalistAgent` | Sits fixed, calls `publish_story` every step one biased, one objective |

Each `CitizenAgent` has one of four **personalities** distributed round-robin:

| Personality | Behaviour |
|---|---|
| `credulous` | Trusts almost anything; spreads quickly |
| `skeptic` | Doubts first, asks questions |
| `critical_thinker` | Needs evidence; most likely to debunk |
| `conformist` | Follows whatever the majority nearby believes |

**Belief states**: `UNINFORMED → BELIEVER / SKEPTIC / DEBUNKED`

**ReAct reasoning loop** (Diagram 1 below):

Every citizen step runs: **Observe** (read memory + nearby agents + recent stories) → **Reason** (LLM evaluates headline content against personality) → **Act** (`update_belief`, `speak_to`, or `move_one_step`).

**Key technical decisions**
- `publish_story` broadcasts to all citizens within `vision` radius no random coin flip, the citizen's LLM decides whether to believe based on headline content and `[MISINFORMATION]` / `[VERIFIED NEWS]` tags.
- `OLLAMA_URL` env var propagated through `app.py → model.py → agents.py → ModuleLLM(api_base=...)` so the model works against a remote Ollama instance, not just localhost (same pattern as the Schelling example).
- Initial datacollector `.collect()` called in `__init__` so Step 0 on the chart shows the true pre-simulation state (all citizens uninformed).
- `move_one_step` now clamps coordinates to grid bounds before calling Mesa eliminates the `"Point out of bounds, non-toroidal"` crash that happens when the LLM suggests walking off the edge.
- Agent placement loop skips occupied cells so the configured `initial_citizens` count always matches what appears on the grid.

---

### Usage Examples

**Default run (remote Ollama)**
```bash
export OLLAMA_URL="http://<your-ollama-host>:11434"
solara run examples/rumor_spreading/app.py
```

**Default run (local Ollama)**
```bash
# No env var needed  falls back to http://localhost:11434
solara run examples/rumor_spreading/app.py
```

**Swap the LLM backend** (in `app.py`):
```python
model_params = {
    "llm_model": "openai/gpt-4o-mini",   # or any litellm-compatible string
    "api_base": None,                      # not needed for OpenAI
    ...
}
```

**Visualisation**

The Solara UI shows the live grid (left) and a belief-state time-series chart (right). Step 0 is always the pre-simulation snapshot with all citizens uninformed (blue).

*Agent Reasoning Loop (Diagram 1):*
<img width="3358" height="1672" alt="image" src="https://github.com/user-attachments/assets/d13dd2c5-5cf5-4c97-824e-df81865cd5db" />


*Live simulation at Step 14  uninformed declining, believers rising as misinformation cascades:*
<img width="1321" height="681" alt="image" src="https://github.com/user-attachments/assets/f9e9dae0-1bf4-40a2-abe6-049eb0a7244a" />


**What you should see**: uninformed (blue) drops as citizens come into journalists' broadcast radius; believers (orange) rise when `credulous` / `conformist` citizens encounter the biased journalist; skeptics (amber) and debunked (pink) rise when `critical_thinker` citizens push back. The final balance depends on the personality mix and which journalist's coverage area citizens spend more time in.

---


### Additional Notes

- **No new core dependencies**  only `mesa-llm`, `mesa`, `solara`, `litellm`, and `rich` (all already in the project).
- The `@record_model` decorator is applied so every run saves a JSON replay under recordings  useful for offline analysis.
- Tested with `ollama/llama3.1:8b` on a remote Ollama instance over ~15 steps. The model runs stable with no unhandled exceptions after the fixes above.
- Pre-commit (`ruff check`, `ruff format`, `pyupgrade`, `codespell`) passes cleanly on all modified files.