### PR TITLE
fix: make built-in tool injection configurable

### DIFF
--- a/mesa_llm/llm_agent.py
+++ b/mesa_llm/llm_agent.py
@@ -78,7 +78,7 @@ class LLMAgent(Agent):
             api_base=api_base,
         )
 
-        self.tool_manager = ToolManager(include_builtins=include_builtin_tools)
+        self.tool_manager = ToolManager(include_builtin_tools=include_builtin_tools)
         self.vision = vision
         self.reasoning = reasoning(agent=self)
         self.system_prompt = system_prompt

--- a/mesa_llm/llm_agent.py
+++ b/mesa_llm/llm_agent.py
@@ -60,6 +60,7 @@ class LLMAgent(Agent):
         internal_state: list[str] | str | None = None,
         step_prompt: str | None = None,
         api_base: str | None = None,
+        include_builtin_tools: bool = True,
     ):
         super().__init__(model=model)
 
@@ -77,7 +78,7 @@ class LLMAgent(Agent):
             api_base=api_base,
         )
 
-        self.tool_manager = ToolManager()
+        self.tool_manager = ToolManager(include_builtins=include_builtin_tools)
         self.vision = vision
         self.reasoning = reasoning(agent=self)
         self.system_prompt = system_prompt

--- a/mesa_llm/tools/tool_manager.py
+++ b/mesa_llm/tools/tool_manager.py
@@ -45,14 +45,14 @@ class ToolManager:
     def __init__(
         self,
         extra_tools: dict[str, Callable] | None = None,
-        include_builtins: bool = True,
+        include_builtin_tools: bool = True,
     ):
         """
         Args:
             extra_tools: additional tool functions to register on this
-                instance (merged on top of globals when *include_builtins*
+                instance (merged on top of globals when *include_builtin_tools*
                 is True, or used as the sole tool set when False).
-            include_builtins: when True (default) the manager starts with
+            include_builtin_tools: when True (default) the manager starts with
                 every globally-registered tool (move_one_step,
                 teleport_to_location, speak_to, …).  Set to False to
                 create a manager with *only* the tools you explicitly
@@ -61,7 +61,7 @@ class ToolManager:
                 tools.
         """
         ToolManager.instances.append(self)
-        self.tools = dict(_GLOBAL_TOOL_REGISTRY) if include_builtins else {}
+        self.tools = dict(_GLOBAL_TOOL_REGISTRY) if include_builtin_tools else {}
         if extra_tools:
             self.tools.update(extra_tools)
 
@@ -117,8 +117,11 @@ class ToolManager:
         return name in self.tools
 
     def remove_tool(self, name: str):
-        """Remove a tool by name. Silently ignores missing tools."""
-        self.tools.pop(name, None)
+        """Remove a tool by name. Logs a debug warning for missing tools."""
+        if name not in self.tools:
+            logger.debug("remove_tool: '%s' not found (available: %s)", name, sorted(self.tools))
+            return
+        self.tools.pop(name)
 
     async def _process_tool_call(
         self, agent: "LLMAgent", tool_call: Any, index: int

--- a/mesa_llm/tools/tool_manager.py
+++ b/mesa_llm/tools/tool_manager.py
@@ -119,7 +119,9 @@ class ToolManager:
     def remove_tool(self, name: str):
         """Remove a tool by name. Logs a debug warning for missing tools."""
         if name not in self.tools:
-            logger.debug("remove_tool: '%s' not found (available: %s)", name, sorted(self.tools))
+            logger.debug(
+                "remove_tool: '%s' not found (available: %s)", name, sorted(self.tools)
+            )
             return
         self.tools.pop(name)
 

--- a/mesa_llm/tools/tool_manager.py
+++ b/mesa_llm/tools/tool_manager.py
@@ -42,11 +42,26 @@ class ToolManager:
 
     instances: ClassVar[list["ToolManager"]] = []
 
-    def __init__(self, extra_tools: dict[str, Callable] | None = None):
-        # start from everything that was decorated
+    def __init__(
+        self,
+        extra_tools: dict[str, Callable] | None = None,
+        include_builtins: bool = True,
+    ):
+        """
+        Args:
+            extra_tools: additional tool functions to register on this
+                instance (merged on top of globals when *include_builtins*
+                is True, or used as the sole tool set when False).
+            include_builtins: when True (default) the manager starts with
+                every globally-registered tool (move_one_step,
+                teleport_to_location, speak_to, …).  Set to False to
+                create a manager with *only* the tools you explicitly
+                provide via *extra_tools*, preventing capability leakage
+                for agents that should not have spatial or communication
+                tools.
+        """
         ToolManager.instances.append(self)
-        self.tools = dict(_GLOBAL_TOOL_REGISTRY)
-        # allow per-agent overrides / reductions
+        self.tools = dict(_GLOBAL_TOOL_REGISTRY) if include_builtins else {}
         if extra_tools:
             self.tools.update(extra_tools)
 
@@ -100,6 +115,10 @@ class ToolManager:
 
     def has_tool(self, name: str) -> bool:
         return name in self.tools
+
+    def remove_tool(self, name: str):
+        """Remove a tool by name. Silently ignores missing tools."""
+        self.tools.pop(name, None)
 
     async def _process_tool_call(
         self, agent: "LLMAgent", tool_call: Any, index: int

--- a/tests/test_tools/test_tool_manager.py
+++ b/tests/test_tools/test_tool_manager.py
@@ -716,11 +716,11 @@ class TestToolManager:
         assert "Async: hello" in result[0]["response"]
 
     # ------------------------------------------------------------------
-    # Tests for include_builtins and remove_tool (issue #90)
+    # Tests for include_builtin_tools and remove_tool (issue #90)
     # ------------------------------------------------------------------
 
-    def test_include_builtins_false_starts_empty(self):
-        """ToolManager(include_builtins=False) should have no global tools."""
+    def test_include_builtin_tools_false_starts_empty(self):
+        """ToolManager(include_builtin_tools=False) should have no global tools."""
 
         # Register some global tools first
         @tool
@@ -736,11 +736,11 @@ class TestToolManager:
             """
             return x
 
-        manager = ToolManager(include_builtins=False)
+        manager = ToolManager(include_builtin_tools=False)
         assert len(manager.tools) == 0
         assert not manager.has_tool("global_tool_a")
 
-    def test_include_builtins_true_includes_global_tools(self):
+    def test_include_builtin_tools_true_includes_global_tools(self):
         """Default ToolManager should include globally registered tools."""
 
         @tool
@@ -756,11 +756,11 @@ class TestToolManager:
             """
             return x
 
-        manager = ToolManager(include_builtins=True)
+        manager = ToolManager(include_builtin_tools=True)
         assert manager.has_tool("global_tool_b")
 
-    def test_include_builtins_false_with_extra_tools(self):
-        """include_builtins=False with extra_tools should only have extras."""
+    def test_include_builtin_tools_false_with_extra_tools(self):
+        """include_builtin_tools=False with extra_tools should only have extras."""
 
         @tool
         def global_should_not_appear(agent, x: int) -> int:
@@ -775,16 +775,21 @@ class TestToolManager:
             """
             return x
 
+        @tool
         def custom_tool(agent, y: str) -> str:
+            """Custom tool for testing.
+
+            Args:
+                agent: Provided automatically.
+                y: Input string.
+
+            Returns:
+                The input string.
+            """
             return y
 
-        custom_tool.__tool_schema__ = {
-            "type": "function",
-            "function": {"name": "custom_tool"},
-        }
-
         manager = ToolManager(
-            include_builtins=False,
+            include_builtin_tools=False,
             extra_tools={"custom_tool": custom_tool},
         )
         assert manager.has_tool("custom_tool")

--- a/tests/test_tools/test_tool_manager.py
+++ b/tests/test_tools/test_tool_manager.py
@@ -714,3 +714,106 @@ class TestToolManager:
         assert len(result) == 1
         assert result[0]["tool_call_id"] == "call_async"
         assert "Async: hello" in result[0]["response"]
+
+    # ------------------------------------------------------------------
+    # Tests for include_builtins and remove_tool (issue #90)
+    # ------------------------------------------------------------------
+
+    def test_include_builtins_false_starts_empty(self):
+        """ToolManager(include_builtins=False) should have no global tools."""
+
+        # Register some global tools first
+        @tool
+        def global_tool_a(agent, x: int) -> int:
+            """Global tool A.
+
+            Args:
+                agent: Provided automatically.
+                x: Input.
+
+            Returns:
+                Output.
+            """
+            return x
+
+        manager = ToolManager(include_builtins=False)
+        assert len(manager.tools) == 0
+        assert not manager.has_tool("global_tool_a")
+
+    def test_include_builtins_true_includes_global_tools(self):
+        """Default ToolManager should include globally registered tools."""
+
+        @tool
+        def global_tool_b(agent, x: int) -> int:
+            """Global tool B.
+
+            Args:
+                agent: Provided automatically.
+                x: Input.
+
+            Returns:
+                Output.
+            """
+            return x
+
+        manager = ToolManager(include_builtins=True)
+        assert manager.has_tool("global_tool_b")
+
+    def test_include_builtins_false_with_extra_tools(self):
+        """include_builtins=False with extra_tools should only have extras."""
+
+        @tool
+        def global_should_not_appear(agent, x: int) -> int:
+            """Should not appear.
+
+            Args:
+                agent: Provided automatically.
+                x: Input.
+
+            Returns:
+                Output.
+            """
+            return x
+
+        def custom_tool(agent, y: str) -> str:
+            return y
+
+        custom_tool.__tool_schema__ = {
+            "type": "function",
+            "function": {"name": "custom_tool"},
+        }
+
+        manager = ToolManager(
+            include_builtins=False,
+            extra_tools={"custom_tool": custom_tool},
+        )
+        assert manager.has_tool("custom_tool")
+        assert not manager.has_tool("global_should_not_appear")
+        assert len(manager.tools) == 1
+
+    def test_remove_tool(self):
+        """remove_tool should remove a tool by name."""
+
+        @tool
+        def removable_tool(agent, x: int) -> int:
+            """Removable tool.
+
+            Args:
+                agent: Provided automatically.
+                x: Input.
+
+            Returns:
+                Output.
+            """
+            return x
+
+        manager = ToolManager()
+        assert manager.has_tool("removable_tool")
+
+        manager.remove_tool("removable_tool")
+        assert not manager.has_tool("removable_tool")
+
+    def test_remove_tool_missing_is_silent(self):
+        """remove_tool should not raise on missing tool names."""
+        manager = ToolManager()
+        manager.remove_tool("nonexistent_tool")  # should not raise


### PR DESCRIPTION
## Summary
Fixes #90

Every `ToolManager` instance automatically copies the global tool registry (`_GLOBAL_TOOL_REGISTRY`), so **all agents** receive `move_one_step`, `teleport_to_location`, and `speak_to` regardless of whether those capabilities make sense for the agent. This causes:

- **Capability leakage** — static entities gain movement tools
- **Tool noise** — LLMs waste reasoning on irrelevant tools
- **Hard-to-debug conflicts** — custom tools can shadow built-ins
- **No local permission reasoning** — cannot restrict agent capabilities

### Changes

**`tool_manager.py`**:
- Add `include_builtins` parameter to `ToolManager.__init__()` (default `True` for full backward compatibility)
- When `False`, the manager starts with an empty tool set — only `extra_tools` (if provided) are registered
- Add `remove_tool(name)` method for fine-grained per-instance tool removal

**`llm_agent.py`**:
- Add `include_builtin_tools` parameter to `LLMAgent.__init__()` that passes through to `ToolManager`

**Tests** (5 new):
- `test_include_builtins_false_starts_empty` — verifies no global tools when disabled
- `test_include_builtins_true_includes_global_tools` — verifies default behavior preserved
- `test_include_builtins_false_with_extra_tools` — verifies only extras are available
- `test_remove_tool` — verifies removal works
- `test_remove_tool_missing_is_silent` — verifies no error on missing tool

### Usage Example

```python
# Agent WITHOUT spatial tools (e.g., dining philosopher)
class Philosopher(LLMAgent):
    def __init__(self, model, **kwargs):
        super().__init__(model, include_builtin_tools=False, **kwargs)
        # Only register tools relevant to this agent
        self.tool_manager.register(pick_up_fork)
        self.tool_manager.register(put_down_fork)

# Agent WITH default tools (backward compatible, no change needed)
class Explorer(LLMAgent):
    def __init__(self, model, **kwargs):
        super().__init__(model, **kwargs)  # gets all built-ins
```

### Test Plan
- [x] All 267 existing tests pass (5 new)
- [x] Pre-commit hooks pass (ruff, codespell)
- [x] Fully backward compatible (default `include_builtins=True`)