### PR TITLE
feat(tools): Add feasible/annotated tool filtering based on agent-state predicates

### DIFF
--- a/mesa_llm/tools/inbuilt_tools.py
+++ b/mesa_llm/tools/inbuilt_tools.py
@@ -18,6 +18,29 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
+# ---------------------------------------------------------------------------
+# Precondition predicates for built-in tools
+# ---------------------------------------------------------------------------
+
+
+def _has_grid_and_position(agent: "LLMAgent") -> bool:
+    """Agent must be placed on a grid or space to move."""
+    grid = getattr(agent.model, "grid", None)
+    space = getattr(agent.model, "space", None)
+    if grid is None and space is None:
+        return False
+    try:
+        _get_agent_position(agent)
+    except (ValueError, AttributeError):
+        return False
+    return True
+
+
+def _has_other_agents(agent: "LLMAgent") -> bool:
+    """At least one other agent must exist for communication."""
+    return sum(1 for a in agent.model.agents if a.unique_id != agent.unique_id) > 0
+
 # Mapping directions to (dx, dy) for Cartesian-style spaces.
 direction_map_xy = {
     "North": (0, 1),
@@ -63,7 +86,7 @@ def _get_agent_position(agent: "LLMAgent") -> Any:
     )
 
 
-@tool
+@tool(requires=_has_grid_and_position)
 def move_one_step(agent: "LLMAgent", direction: str) -> str:
     """
     Moves agents one step in specified cardinal/diagonal directions (North, South, East, West, NorthEast, NorthWest, SouthEast, SouthWest). Automatically handles different Mesa grid types including SingleGrid, MultiGrid, OrthogonalGrids, and ContinuousSpace.
@@ -153,7 +176,7 @@ def move_one_step(agent: "LLMAgent", direction: str) -> str:
     )
 
 
-@tool
+@tool(requires=_has_grid_and_position)
 def teleport_to_location(
     agent: "LLMAgent",
     target_coordinates: list[int | float],
@@ -191,7 +214,7 @@ def teleport_to_location(
     return f"agent {agent.unique_id} moved to {target_coordinates}."
 
 
-@tool
+@tool(requires=_has_other_agents)
 def speak_to(
     agent: "LLMAgent", listener_agents_unique_ids: list[int], message: str
 ) -> str:

--- a/mesa_llm/tools/inbuilt_tools.py
+++ b/mesa_llm/tools/inbuilt_tools.py
@@ -41,6 +41,7 @@ def _has_other_agents(agent: "LLMAgent") -> bool:
     """At least one other agent must exist for communication."""
     return sum(1 for a in agent.model.agents if a.unique_id != agent.unique_id) > 0
 
+
 # Mapping directions to (dx, dy) for Cartesian-style spaces.
 direction_map_xy = {
     "North": (0, 1),

--- a/mesa_llm/tools/tool_decorator.py
+++ b/mesa_llm/tools/tool_decorator.py
@@ -317,6 +317,7 @@ def tool(
     *,
     tool_manager: ToolManager | None = None,
     ignore_agent: bool = True,
+    requires: Callable[..., bool] | None = None,
 ):
     """
     Converts Python functions into LLM-compatible tools by automatically generating JSON schemas from type hints and docstrings. Handles parameter validation, type conversion, and integration with the global tool registry. This module automatically extracts parameter descriptions from Google-style docstrings, injects calling agents into functions expecting an `agent` parameter, and integrates with the global tool registry for automatic availability across all ToolManager instances.
@@ -324,6 +325,10 @@ def tool(
     Args:
         fn: The function to decorate.
         tool_manager : the optional tool manager to add the function to
+        requires: an optional predicate ``(agent) -> bool`` that returns
+            True when this tool is usable by the given agent.  Used by
+            ``ToolManager.get_feasible_tools_schema`` to filter out tools
+            whose preconditions are not met.
 
     Returns:
         The decorated function.
@@ -381,6 +386,7 @@ def tool(
         }
 
         func.__tool_schema__ = schema
+        func.__tool_requires__ = requires
 
         if tool_manager:
             tool_manager.register(func)

--- a/mesa_llm/tools/tool_manager.py
+++ b/mesa_llm/tools/tool_manager.py
@@ -92,6 +92,76 @@ class ToolManager:
 
         return [fn.__tool_schema__ for fn in self.tools.values()]
 
+    def _is_tool_feasible(self, fn: Callable, agent: "LLMAgent") -> bool:
+        """Check whether *fn*'s ``__tool_requires__`` predicate passes."""
+        predicate = getattr(fn, "__tool_requires__", None)
+        if predicate is None:
+            return True
+        try:
+            return bool(predicate(agent))
+        except Exception:
+            return False
+
+    def get_feasible_tools_schema(
+        self,
+        agent: "LLMAgent",
+        selected_tools: list[str] | None = None,
+    ) -> list[dict]:
+        """Return schemas only for tools whose preconditions are met.
+
+        Tools decorated with ``@tool(requires=...)`` are checked against
+        the given *agent*.  Tools without a *requires* predicate are
+        always included.
+        """
+        candidates = (
+            {name: self.tools[name] for name in selected_tools if name in self.tools}
+            if selected_tools
+            else self.tools
+        )
+        return [
+            fn.__tool_schema__
+            for fn in candidates.values()
+            if self._is_tool_feasible(fn, agent)
+        ]
+
+    def get_annotated_tools_schema(
+        self,
+        agent: "LLMAgent",
+        selected_tools: list[str] | None = None,
+    ) -> list[dict]:
+        """Return all schemas with an ``available`` annotation.
+
+        Each schema dict gets a top-level ``"available"`` key (bool) and
+        an ``"unavailable_reason"`` key (str or None) so that planners
+        can reason about infeasible tools without losing awareness of
+        their existence.
+        """
+        candidates = (
+            {name: self.tools[name] for name in selected_tools if name in self.tools}
+            if selected_tools
+            else self.tools
+        )
+        result = []
+        for fn in candidates.values():
+            schema = dict(fn.__tool_schema__)
+            predicate = getattr(fn, "__tool_requires__", None)
+            if predicate is None:
+                schema["available"] = True
+                schema["unavailable_reason"] = None
+            else:
+                try:
+                    ok = bool(predicate(agent))
+                except Exception as exc:
+                    ok = False
+                    schema["unavailable_reason"] = str(exc)
+                else:
+                    schema["unavailable_reason"] = (
+                        None if ok else "Precondition not met"
+                    )
+                schema["available"] = ok
+            result.append(schema)
+        return result
+
     def call(self, name: str, arguments: dict) -> str:
         """Call a registered tool with validated args"""
         if name not in self.tools:

--- a/tests/test_tools/test_feasible_tools.py
+++ b/tests/test_tools/test_feasible_tools.py
@@ -1,0 +1,261 @@
+"""Tests for feasible/annotated tool filtering (issue #148).
+
+Verifies that ToolManager.get_feasible_tools_schema and
+get_annotated_tools_schema correctly filter and annotate tools
+based on agent-state predicates.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from mesa_llm.tools.inbuilt_tools import _has_grid_and_position, _has_other_agents
+from mesa_llm.tools.tool_decorator import _GLOBAL_TOOL_REGISTRY, tool
+from mesa_llm.tools.tool_manager import ToolManager
+
+
+def _always_true(agent) -> bool:
+    return True
+
+
+def _always_false(agent) -> bool:
+    return False
+
+
+def _has_energy(agent) -> bool:
+    return getattr(agent, "energy", 0) > 0
+
+
+def _register_test_tools():
+    """Register test tools into the global registry and return them."""
+
+    @tool(requires=_always_true)
+    def always_available(agent, x: int) -> int:
+        """Always available.
+
+        Args:
+            agent: Provided automatically.
+            x: Input.
+
+        Returns:
+            Output.
+        """
+        return x
+
+    @tool(requires=_always_false)
+    def never_available(agent, x: int) -> int:
+        """Never available.
+
+        Args:
+            agent: Provided automatically.
+            x: Input.
+
+        Returns:
+            Output.
+        """
+        return x
+
+    @tool(requires=_has_energy)
+    def energy_tool(agent, x: int) -> int:
+        """Requires energy > 0.
+
+        Args:
+            agent: Provided automatically.
+            x: Input.
+
+        Returns:
+            Output.
+        """
+        return x
+
+    @tool
+    def no_requires_tool(agent, x: int) -> int:
+        """No requires predicate — always feasible.
+
+        Args:
+            agent: Provided automatically.
+            x: Input.
+
+        Returns:
+            Output.
+        """
+        return x
+
+    return {
+        "always_available": always_available,
+        "never_available": never_available,
+        "energy_tool": energy_tool,
+        "no_requires_tool": no_requires_tool,
+    }
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Start each test with a clean global registry and fresh tools."""
+    saved = dict(_GLOBAL_TOOL_REGISTRY)
+    saved_instances = list(ToolManager.instances)
+    _GLOBAL_TOOL_REGISTRY.clear()
+    ToolManager.instances.clear()
+    # Re-register our test tools into the now-clean registry
+    _register_test_tools()
+    yield
+    _GLOBAL_TOOL_REGISTRY.clear()
+    _GLOBAL_TOOL_REGISTRY.update(saved)
+    ToolManager.instances.clear()
+    ToolManager.instances.extend(saved_instances)
+
+
+# ===================================================================
+# get_feasible_tools_schema tests
+# ===================================================================
+class TestGetFeasibleToolsSchema:
+    def test_filters_out_infeasible_tools(self):
+        manager = ToolManager()
+        agent = Mock()
+        schemas = manager.get_feasible_tools_schema(agent)
+        names = {s["function"]["name"] for s in schemas}
+        assert "always_available" in names
+        assert "never_available" not in names
+
+    def test_tools_without_requires_always_included(self):
+        manager = ToolManager()
+        agent = Mock()
+        schemas = manager.get_feasible_tools_schema(agent)
+        names = {s["function"]["name"] for s in schemas}
+        assert "no_requires_tool" in names
+
+    def test_predicate_receives_agent_state(self):
+        manager = ToolManager()
+
+        agent_with_energy = Mock()
+        agent_with_energy.energy = 10
+        schemas = manager.get_feasible_tools_schema(agent_with_energy)
+        names = {s["function"]["name"] for s in schemas}
+        assert "energy_tool" in names
+
+        agent_no_energy = Mock()
+        agent_no_energy.energy = 0
+        schemas = manager.get_feasible_tools_schema(agent_no_energy)
+        names = {s["function"]["name"] for s in schemas}
+        assert "energy_tool" not in names
+
+    def test_with_selected_tools(self):
+        manager = ToolManager()
+        agent = Mock()
+        schemas = manager.get_feasible_tools_schema(
+            agent, selected_tools=["always_available", "never_available"]
+        )
+        names = {s["function"]["name"] for s in schemas}
+        assert names == {"always_available"}
+
+    def test_predicate_exception_treated_as_infeasible(self):
+        def broken_predicate(agent):
+            raise RuntimeError("oops")
+
+        @tool(requires=broken_predicate)
+        def broken_tool(agent, x: int) -> int:
+            """Broken predicate.
+
+            Args:
+                agent: Provided automatically.
+                x: Input.
+
+            Returns:
+                Output.
+            """
+            return x
+
+        manager = ToolManager()
+        agent = Mock()
+        schemas = manager.get_feasible_tools_schema(agent)
+        names = {s["function"]["name"] for s in schemas}
+        assert "broken_tool" not in names
+
+
+# ===================================================================
+# get_annotated_tools_schema tests
+# ===================================================================
+class TestGetAnnotatedToolsSchema:
+    def test_all_tools_returned_with_annotations(self):
+        manager = ToolManager()
+        agent = Mock()
+        schemas = manager.get_annotated_tools_schema(agent)
+        names = {s["function"]["name"] for s in schemas}
+        assert "always_available" in names
+        assert "never_available" in names
+        assert "no_requires_tool" in names
+
+    def test_available_annotation_correct(self):
+        manager = ToolManager()
+        agent = Mock()
+        schemas = manager.get_annotated_tools_schema(agent)
+        by_name = {s["function"]["name"]: s for s in schemas}
+
+        assert by_name["always_available"]["available"] is True
+        assert by_name["always_available"]["unavailable_reason"] is None
+
+        assert by_name["never_available"]["available"] is False
+        assert by_name["never_available"]["unavailable_reason"] is not None
+
+        assert by_name["no_requires_tool"]["available"] is True
+        assert by_name["no_requires_tool"]["unavailable_reason"] is None
+
+    def test_annotated_with_selected_tools(self):
+        manager = ToolManager()
+        agent = Mock()
+        schemas = manager.get_annotated_tools_schema(
+            agent, selected_tools=["never_available"]
+        )
+        assert len(schemas) == 1
+        assert schemas[0]["available"] is False
+
+
+# ===================================================================
+# Built-in predicate tests (_has_grid_and_position, _has_other_agents)
+# ===================================================================
+class TestBuiltInPredicates:
+    def test_has_grid_and_position_no_grid_no_space(self):
+        agent = Mock()
+        agent.model.grid = None
+        agent.model.space = None
+        assert _has_grid_and_position(agent) is False
+
+    def test_has_grid_and_position_with_grid_and_pos(self):
+        agent = Mock()
+        agent.model.grid = Mock()
+        agent.model.space = None
+        agent.cell = None
+        agent.pos = (1, 2)
+        assert _has_grid_and_position(agent) is True
+
+    def test_has_grid_and_position_with_cell_coordinate(self):
+        agent = Mock()
+        agent.model.grid = Mock()
+        agent.model.space = None
+        agent.cell = Mock()
+        agent.cell.coordinate = (3, 4)
+        assert _has_grid_and_position(agent) is True
+
+    def test_has_grid_and_position_no_position(self):
+        """Grid exists but agent has no position — should return False."""
+        agent = Mock()
+        agent.model.grid = Mock()
+        agent.model.space = None
+        agent.cell = None
+        agent.pos = None
+        agent.position = None
+        assert _has_grid_and_position(agent) is False
+
+    def test_has_other_agents_true(self):
+        other = Mock()
+        other.unique_id = 2
+        agent = Mock()
+        agent.unique_id = 1
+        agent.model.agents = [agent, other]
+        assert _has_other_agents(agent) is True
+
+    def test_has_other_agents_false_alone(self):
+        agent = Mock()
+        agent.unique_id = 1
+        agent.model.agents = [agent]
+        assert _has_other_agents(agent) is False


### PR DESCRIPTION
## Summary

Closes #148.

Adds support for conditionally filtering tools based on agent-state predicates, so reasoning strategies can present only feasible tools to the LLM (or annotate infeasible ones for planner awareness).

## Changes

### `@tool(requires=...)` decorator parameter
- New optional `requires` keyword on `@tool`: a callable `(agent) -> bool` that returns `True` when the tool is usable by the given agent.
- The predicate is stored as `fn.__tool_requires__` on the decorated function.

### `ToolManager` methods
- **`_is_tool_feasible(fn, agent)`** — checks the `__tool_requires__` predicate; returns `True` when no predicate is set or when it passes, `False` on failure or exception.
- **`get_feasible_tools_schema(agent, selected_tools=None)`** — returns schemas only for tools whose preconditions are satisfied.
- **`get_annotated_tools_schema(agent, selected_tools=None)`** — returns all tool schemas with added `available` (bool) and `unavailable_reason` (str | None) keys, so planners can reason about currently-infeasible tools.

### Built-in tool predicates
- `_has_grid_and_position(agent)` — applied to `move_one_step` and `teleport_to_location`.
- `_has_other_agents(agent)` — applied to `speak_to`.

### Tests
- 8 new tests in `tests/test_tools/test_feasible_tools.py` covering:
  - Filtering infeasible tools
  - Tools without `requires` always included
  - Predicate receives correct agent state
  - `selected_tools` interaction
  - Exception in predicate treated as infeasible
  - Annotated schema correctness (`available`, `unavailable_reason`)

## Backward Compatibility

- `requires` defaults to `None`, so all existing `@tool` decorations are unaffected.
- `get_all_tools_schema()` remains unchanged; the new methods are additive.
- Reasoning strategies can adopt the new methods at their own pace.