### PR TITLE
Fix Asynchronous Event Loop Blocking in Mesa-LLM Parallel Stepping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -229,7 +229,7 @@ MANIFEST
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt
-
+uv.lock
 # Unit test / coverage reports
 htmlcov/
 .tox/

--- a/mesa_llm/parallel_stepping.py
+++ b/mesa_llm/parallel_stepping.py
@@ -33,7 +33,7 @@ async def step_agents_parallel(agents: list[Agent | LLMAgent]) -> None:
 
 async def _sync_step(agent: Agent) -> None:
     """Run synchronous step in async context."""
-    agent.step()
+    await asyncio.to_thread(agent.step)
 
 
 def step_agents_multithreaded(agents: list[Agent | LLMAgent]) -> None:

--- a/mesa_llm/tools/tool_manager.py
+++ b/mesa_llm/tools/tool_manager.py
@@ -137,7 +137,7 @@ class ToolManager:
             if inspect.iscoroutinefunction(function_to_call):
                 function_response = await function_to_call(**filtered_args)
             else:
-                function_response = function_to_call(**filtered_args)
+                function_response = await asyncio.to_thread(function_to_call, **filtered_args)
 
             # Only treat None as empty
             if function_response is None:

--- a/mesa_llm/tools/tool_manager.py
+++ b/mesa_llm/tools/tool_manager.py
@@ -137,7 +137,9 @@ class ToolManager:
             if inspect.iscoroutinefunction(function_to_call):
                 function_response = await function_to_call(**filtered_args)
             else:
-                function_response = await asyncio.to_thread(function_to_call, **filtered_args)
+                function_response = await asyncio.to_thread(
+                    function_to_call, **filtered_args
+                )
 
             # Only treat None as empty
             if function_response is None:


### PR DESCRIPTION
### Summary
Fixes asynchronous event loop blocking when executing synchronous `agent.step()` functions and synchronous tool calls during parallel agent execution. 

### Bug / Issue
When utilizing `parallel_stepping.py`'s asynchronous concurrency features in Mesa-LLM, standard Mesa Agents invoking the synchronous `agent.step()` method were doing so directly inside the `asyncio` event loop. Similarly, non-async tool functions parsed inside `tools/tool_manager.py` were invoked synchronously. Because Python `asyncio` runs on a single thread, any long-running or computationally expensive synchronous method call fully blocked the entire event loop, stalling all agents from operating concurrently and adding significant latency.

### Implementation
- `mesa_llm/parallel_stepping.py`: Updated `_sync_step` function to use `await asyncio.to_thread(agent.step)` instead of blindly calling `agent.step()`.
- `mesa_llm/tools/tool_manager.py`: Updated `_process_tool_call` to check if a function is synchronous. If so, it invokes the tool using `await asyncio.to_thread(function_to_call, **filtered_args)`.

**Code Changes:**
```diff
diff --git a/mesa_llm/parallel_stepping.py b/mesa_llm/parallel_stepping.py
--- a/mesa_llm/parallel_stepping.py
+++ b/mesa_llm/parallel_stepping.py
@@ -33,7 +33,7 @@ async def step_agents_parallel(agents: list[Agent | LLMAgent]) -> None:
 
 async def _sync_step(agent: Agent) -> None:
     """Run synchronous step in async context."""
-    agent.step()
+    await asyncio.to_thread(agent.step)
 
 
 def step_agents_multithreaded(agents: list[Agent | LLMAgent]) -> None:
diff --git a/mesa_llm/tools/tool_manager.py b/mesa_llm/tools/tool_manager.py
--- a/mesa_llm/tools/tool_manager.py
+++ b/mesa_llm/tools/tool_manager.py
@@ -137,7 +137,7 @@ class ToolManager:
             if inspect.iscoroutinefunction(function_to_call):
                 function_response = await function_to_call(**filtered_args)
             else:
-                function_response = function_to_call(**filtered_args)
+                function_response = await asyncio.to_thread(function_to_call, **filtered_args)
 
             # Only treat None as empty
             if function_response is None:
```

### Testing
- [x] Verified by running the entire `test_parallel_stepping.py` and `test_tools` test directories using `pytest`.
- 66 comprehensive tests passed successfully locally with zero regressions.

**Pytest Output:**
```bash
$ uv run pytest tests/test_parallel_stepping.py tests/test_tools/
========================= test session starts ==========================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/hari/gsoc/mesa-llm
configfile: pyproject.toml
plugins: anyio-4.8.0, html-4.1.1, cov-7.0.0, asyncio-1.3.0, metadata-3.1.1, mock-3.15.1
asyncio: mode=Mode.STRICT, openai_api_base=None, openai_api_key=None
collected 66 items                                                     

tests/test_parallel_stepping.py ....                             [  6%]
tests/test_tools/test_tool_decorator.py ..........               [ 21%]
tests/test_tools/test_tool_manager.py .......................... [ 60%]
..........................                                       [100%]

========================= warnings summary =========================
tests/test_parallel_stepping.py::test_step_agents_parallel
tests/test_parallel_stepping.py::test_step_agents_multithreaded
tests/test_parallel_stepping.py::test_automatic_parallel_shuffle_do
tests/test_parallel_stepping.py::test_step_agents_parallel_sync_in_running_loop
  /home/hari/gsoc/mesa-llm/.venv/lib/python3.12/site-packages/mesa/mesa_logging.py:112: FutureWarning: The use of the `seed` keyword argument is deprecated, use `rng` instead. No functional changes.
    res = func(*args, **kwargs)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================== 66 passed, 4 warnings in 0.42s ==================
```

### Additional Notes
This correctly delegates blocking sync I/O calls to background threads, yielding control back to the `asyncio` event loop and providing major latency and concurrency improvements in large Mesa agent simulations.
