### PR TITLE
feat : Structured llm reasoning added for auditable and constrained decision making

### DIFF
--- a/mesa_llm/module_llm.py
+++ b/mesa_llm/module_llm.py
@@ -8,6 +8,7 @@ from litellm.exceptions import (
     RateLimitError,
     Timeout,
 )
+from pydantic import BaseModel
 from tenacity import AsyncRetrying, retry, retry_if_exception_type, wait_exponential
 
 RETRYABLE_EXCEPTIONS = (
@@ -79,7 +80,11 @@ class ModuleLLM:
                 self.llm_model,
             )
 
-    def _build_messages(self, prompt: str | list[str] | None = None) -> list[dict]:
+    def _build_messages(
+        self,
+        prompt: str | list[str] | None = None,
+        system_prompt: str | None = None,
+    ) -> list[dict]:
         """
         Format the prompt messages for the LLM of the form : {"role": ..., "content": ...}
 
@@ -92,7 +97,8 @@ class ModuleLLM:
         messages = []
 
         # Always include a system message. Default to empty string if no system prompt to support Ollama
-        system_content = self.system_prompt if self.system_prompt else ""
+        system_content = system_prompt if system_prompt is not None else self.system_prompt
+        system_content = system_content if system_content else ""
         messages.append({"role": "system", "content": system_content})
 
         if prompt:
@@ -103,6 +109,23 @@ class ModuleLLM:
                 messages.extend([{"role": "user", "content": p} for p in prompt])
 
         return messages
+
+    def parse_structured_output(
+        self,
+        response,
+        response_model: type[BaseModel],
+    ) -> BaseModel:
+        """Normalize structured LLM output into the requested pydantic model."""
+        message = response.choices[0].message
+        parsed = getattr(message, "parsed", None)
+
+        if isinstance(parsed, response_model):
+            return parsed
+
+        if parsed is not None:
+            return response_model.model_validate(parsed)
+
+        return response_model.model_validate_json(message.content)
 
     @retry(
         wait=wait_exponential(multiplier=1, min=1, max=60),
@@ -115,6 +138,7 @@ class ModuleLLM:
         tool_schema: list[dict] | None = None,
         tool_choice: str = "auto",
         response_format: dict | object | None = None,
+        system_prompt: str | None = None,
     ) -> str:
         """
         Generate a response from the LLM using litellm based on the prompt
@@ -129,7 +153,7 @@ class ModuleLLM:
             The response from the LLM
         """
 
-        messages = self._build_messages(prompt)
+        messages = self._build_messages(prompt, system_prompt=system_prompt)
 
         completion_kwargs = {
             "model": self.llm_model,
@@ -151,11 +175,12 @@ class ModuleLLM:
         tool_schema: list[dict] | None = None,
         tool_choice: str = "auto",
         response_format: dict | object | None = None,
+        system_prompt: str | None = None,
     ) -> str:
         """
         Asynchronous version of generate() method for parallel LLM calls.
         """
-        messages = self._build_messages(prompt)
+        messages = self._build_messages(prompt, system_prompt=system_prompt)
         async for attempt in AsyncRetrying(
             wait=wait_exponential(multiplier=1, min=1, max=60),
             retry=retry_if_exception_type(RETRYABLE_EXCEPTIONS),

--- a/mesa_llm/module_llm.py
+++ b/mesa_llm/module_llm.py
@@ -97,7 +97,9 @@ class ModuleLLM:
         messages = []
 
         # Always include a system message. Default to empty string if no system prompt to support Ollama
-        system_content = system_prompt if system_prompt is not None else self.system_prompt
+        system_content = (
+            system_prompt if system_prompt is not None else self.system_prompt
+        )
         system_content = system_content if system_content else ""
         messages.append({"role": "system", "content": system_content})
 

--- a/mesa_llm/reasoning/decision.py
+++ b/mesa_llm/reasoning/decision.py
@@ -1,4 +1,3 @@
-import json
 from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field
@@ -68,8 +67,18 @@ class DecisionReasoning(Reasoning):
         """
 
     def get_decision_prompt(self, obs: Observation) -> list[str]:
-        prompt_list = [self.agent.memory.get_prompt_ready()]
-        last_communication = self.agent.memory.get_communication_history()
+        prompt_list = []
+
+        get_prompt_ready = getattr(self.agent.memory, "get_prompt_ready", None)
+        if callable(get_prompt_ready):
+            prompt_list.append(get_prompt_ready())
+
+        get_communication_history = getattr(
+            self.agent.memory, "get_communication_history", None
+        )
+        last_communication = (
+            get_communication_history() if callable(get_communication_history) else ""
+        )
 
         if last_communication:
             prompt_list.append("last communication: \n" + str(last_communication))
@@ -77,6 +86,19 @@ class DecisionReasoning(Reasoning):
             prompt_list.append("current observation: \n" + str(obs))
 
         return prompt_list
+
+    def _parse_decision_output(self, response) -> dict:
+        """Normalize structured LLM output into a dictionary."""
+        message = response.choices[0].message
+        parsed = getattr(message, "parsed", None)
+
+        if isinstance(parsed, DecisionOutput):
+            return parsed.model_dump()
+
+        if isinstance(parsed, dict):
+            return DecisionOutput.model_validate(parsed).model_dump()
+
+        return DecisionOutput.model_validate_json(message.content).model_dump()
 
     def plan(
         self,
@@ -112,7 +134,7 @@ class DecisionReasoning(Reasoning):
             response_format=DecisionOutput,
         )
 
-        formatted_response = json.loads(rsp.choices[0].message.content)
+        formatted_response = self._parse_decision_output(rsp)
         self.agent.memory.add_to_memory(type="decision", content=formatted_response)
 
         if hasattr(self.agent, "_step_display_data"):
@@ -160,7 +182,7 @@ class DecisionReasoning(Reasoning):
             response_format=DecisionOutput,
         )
 
-        formatted_response = json.loads(rsp.choices[0].message.content)
+        formatted_response = self._parse_decision_output(rsp)
         await self.agent.memory.aadd_to_memory(
             type="decision", content=formatted_response
         )

--- a/mesa_llm/reasoning/decision.py
+++ b/mesa_llm/reasoning/decision.py
@@ -15,7 +15,7 @@ class DecisionOption(BaseModel):
     score: float = Field(
         ge=0.0,
         le=1.0,
-        description="Relative evaluation score for this option in the current context."
+        description="Relative evaluation score for this option in the current context.",
     )
 
 

--- a/mesa_llm/reasoning/decision.py
+++ b/mesa_llm/reasoning/decision.py
@@ -13,6 +13,8 @@ class DecisionOption(BaseModel):
     description: str
     tradeoffs: list[str]
     score: float = Field(
+        ge=0.0,
+        le=1.0,
         description="Relative evaluation score for this option in the current context."
     )
 
@@ -87,19 +89,6 @@ class DecisionReasoning(Reasoning):
 
         return prompt_list
 
-    def _parse_decision_output(self, response) -> dict:
-        """Normalize structured LLM output into a dictionary."""
-        message = response.choices[0].message
-        parsed = getattr(message, "parsed", None)
-
-        if isinstance(parsed, DecisionOutput):
-            return parsed.model_dump()
-
-        if isinstance(parsed, dict):
-            return DecisionOutput.model_validate(parsed).model_dump()
-
-        return DecisionOutput.model_validate_json(message.content).model_dump()
-
     def plan(
         self,
         prompt: str | None = None,
@@ -113,7 +102,6 @@ class DecisionReasoning(Reasoning):
         if obs is None:
             obs = self.agent.generate_obs()
 
-        self.agent.llm.system_prompt = self.get_decision_system_prompt()
         prompt_list = self.get_decision_prompt(obs)
 
         if prompt is not None:
@@ -132,9 +120,12 @@ class DecisionReasoning(Reasoning):
             tool_schema=selected_tools_schema,
             tool_choice="none",
             response_format=DecisionOutput,
+            system_prompt=self.get_decision_system_prompt(),
         )
 
-        formatted_response = self._parse_decision_output(rsp)
+        formatted_response = self.agent.llm.parse_structured_output(
+            rsp, DecisionOutput
+        ).model_dump()
         self.agent.memory.add_to_memory(type="decision", content=formatted_response)
 
         if hasattr(self.agent, "_step_display_data"):
@@ -161,7 +152,6 @@ class DecisionReasoning(Reasoning):
         if obs is None:
             obs = await self.agent.agenerate_obs()
 
-        self.agent.llm.system_prompt = self.get_decision_system_prompt()
         prompt_list = self.get_decision_prompt(obs)
 
         if prompt is not None:
@@ -180,9 +170,12 @@ class DecisionReasoning(Reasoning):
             tool_schema=selected_tools_schema,
             tool_choice="none",
             response_format=DecisionOutput,
+            system_prompt=self.get_decision_system_prompt(),
         )
 
-        formatted_response = self._parse_decision_output(rsp)
+        formatted_response = self.agent.llm.parse_structured_output(
+            rsp, DecisionOutput
+        ).model_dump()
         await self.agent.memory.aadd_to_memory(
             type="decision", content=formatted_response
         )

--- a/mesa_llm/reasoning/decision.py
+++ b/mesa_llm/reasoning/decision.py
@@ -1,0 +1,177 @@
+import json
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+from mesa_llm.reasoning.reasoning import Observation, Plan, Reasoning
+
+if TYPE_CHECKING:
+    from mesa_llm.llm_agent import LLMAgent
+
+
+class DecisionOption(BaseModel):
+    name: str
+    description: str
+    tradeoffs: list[str]
+    score: float = Field(
+        description="Relative evaluation score for this option in the current context."
+    )
+
+
+class DecisionOutput(BaseModel):
+    goal: str
+    constraints: list[str]
+    known_facts: list[str]
+    unknowns: list[str]
+    assumptions: list[str]
+    options: list[DecisionOption]
+    chosen_option: str
+    rationale: str
+    confidence: float = Field(ge=0.0, le=1.0)
+    risks: list[str]
+    next_action: str
+
+
+class DecisionReasoning(Reasoning):
+    """
+    Structured decision-making reasoning that returns a strict JSON object before
+    converting the selected next action into tool calls.
+    """
+
+    def __init__(self, agent: "LLMAgent"):
+        super().__init__(agent=agent)
+
+    def get_decision_system_prompt(self) -> str:
+        return """
+        You are an autonomous agent operating within a simulation environment.
+
+        Your task is to analyze your current observation and memory to make a highly structured, optimal decision.
+        Do not produce free-form chain-of-thought prose. You must evaluate the situation and return a strict JSON object matching the required schema.
+
+        Your response must include:
+        - goal: Your current primary objective within the simulation.
+        - constraints: Any rules, resource limits, or environmental boundaries restricting your actions.
+        - known_facts: Verified data strictly grounded in your current observation or historical memory.
+        - unknowns: Critical missing information required for perfect decision-making.
+        - assumptions: Logical inferences made to bridge the gap between known facts and unknowns.
+        - options: A list of distinct, executable choices currently available to you. Each must include a name, description, tradeoffs, and a relative evaluation score.
+        - chosen_option: The exact name of the best option selected from the list above.
+        - rationale: A concise, logical justification for why this option was chosen over the alternatives.
+        - confidence: A float between 0.0 and 1.0 representing your certainty in this decision.
+        - risks: Potential negative outcomes or failure states associated with the chosen option.
+        - next_action: A single, concrete, and strictly formatted executable command.
+
+        Execution Requirements:
+        1. Ground all known_facts entirely in the provided observation context. Do not hallucinate simulation state or capabilities.
+        2. next_action must strictly match an available execution command. Do not invent tools.
+        3. If information is heavily constrained or missing, explicitly reflect this by lowering the confidence score and detailing the danger in risks.
+        """
+
+    def get_decision_prompt(self, obs: Observation) -> list[str]:
+        prompt_list = [self.agent.memory.get_prompt_ready()]
+        last_communication = self.agent.memory.get_communication_history()
+
+        if last_communication:
+            prompt_list.append("last communication: \n" + str(last_communication))
+        if obs:
+            prompt_list.append("current observation: \n" + str(obs))
+
+        return prompt_list
+
+    def plan(
+        self,
+        prompt: str | None = None,
+        obs: Observation | None = None,
+        ttl: int = 1,
+        selected_tools: list[str] | None = None,
+    ) -> Plan:
+        """
+        Plan the next action through a structured decision artifact.
+        """
+        if obs is None:
+            obs = self.agent.generate_obs()
+
+        self.agent.llm.system_prompt = self.get_decision_system_prompt()
+        prompt_list = self.get_decision_prompt(obs)
+
+        if prompt is not None:
+            prompt_list.append(prompt)
+        elif self.agent.step_prompt is not None:
+            prompt_list.append(self.agent.step_prompt)
+        else:
+            raise ValueError("No prompt provided and agent.step_prompt is None.")
+
+        selected_tools_schema = self.agent.tool_manager.get_all_tools_schema(
+            selected_tools
+        )
+
+        rsp = self.agent.llm.generate(
+            prompt=prompt_list,
+            tool_schema=selected_tools_schema,
+            tool_choice="none",
+            response_format=DecisionOutput,
+        )
+
+        formatted_response = json.loads(rsp.choices[0].message.content)
+        self.agent.memory.add_to_memory(type="decision", content=formatted_response)
+
+        if hasattr(self.agent, "_step_display_data"):
+            self.agent._step_display_data["plan_content"] = formatted_response[
+                "rationale"
+            ]
+
+        return self.execute_tool_call(
+            formatted_response["next_action"],
+            selected_tools=selected_tools,
+            ttl=ttl,
+        )
+
+    async def aplan(
+        self,
+        prompt: str | None = None,
+        obs: Observation | None = None,
+        ttl: int = 1,
+        selected_tools: list[str] | None = None,
+    ) -> Plan:
+        """
+        Asynchronous version of plan() method for parallel planning.
+        """
+        if obs is None:
+            obs = await self.agent.agenerate_obs()
+
+        self.agent.llm.system_prompt = self.get_decision_system_prompt()
+        prompt_list = self.get_decision_prompt(obs)
+
+        if prompt is not None:
+            prompt_list.append(prompt)
+        elif self.agent.step_prompt is not None:
+            prompt_list.append(self.agent.step_prompt)
+        else:
+            raise ValueError("No prompt provided and agent.step_prompt is None.")
+
+        selected_tools_schema = self.agent.tool_manager.get_all_tools_schema(
+            selected_tools
+        )
+
+        rsp = await self.agent.llm.agenerate(
+            prompt=prompt_list,
+            tool_schema=selected_tools_schema,
+            tool_choice="none",
+            response_format=DecisionOutput,
+        )
+
+        formatted_response = json.loads(rsp.choices[0].message.content)
+        await self.agent.memory.aadd_to_memory(
+            type="decision", content=formatted_response
+        )
+
+        if hasattr(self.agent, "_step_display_data"):
+            self.agent._step_display_data["plan_content"] = formatted_response[
+                "rationale"
+            ]
+
+        return await self.aexecute_tool_call(
+            formatted_response["next_action"],
+            selected_tools=selected_tools,
+            ttl=ttl,
+        )

--- a/tests/test_module_llm.py
+++ b/tests/test_module_llm.py
@@ -1,7 +1,8 @@
 import os
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
+from pydantic import BaseModel
 
 from mesa_llm.module_llm import ModuleLLM
 
@@ -81,6 +82,36 @@ class TestModuleLLM:
         llm = ModuleLLM(llm_model="openai/gpt-4o")
         messages = llm._build_messages(prompt=None)
         assert messages == [{"role": "system", "content": ""}]
+
+        messages = llm._build_messages(
+            "Hello, how are you?", system_prompt="Per-call prompt"
+        )
+        assert messages == [
+            {"role": "system", "content": "Per-call prompt"},
+            {"role": "user", "content": "Hello, how are you?"},
+        ]
+
+    def test_parse_structured_output(self):
+        class DummyOutput(BaseModel):
+            answer: str
+
+        llm = ModuleLLM(llm_model="openai/gpt-4o")
+
+        response = Mock()
+        response.choices = [Mock()]
+        response.choices[0].message = Mock()
+        response.choices[0].message.parsed = DummyOutput(answer="parsed")
+        parsed = llm.parse_structured_output(response, DummyOutput)
+        assert parsed.answer == "parsed"
+
+        response.choices[0].message.parsed = {"answer": "dict"}
+        parsed = llm.parse_structured_output(response, DummyOutput)
+        assert parsed.answer == "dict"
+
+        response.choices[0].message.parsed = None
+        response.choices[0].message.content = '{"answer":"json"}'
+        parsed = llm.parse_structured_output(response, DummyOutput)
+        assert parsed.answer == "json"
 
     def test_generate(self, monkeypatch, llm_response_factory):
         monkeypatch.setattr(

--- a/tests/test_reasoning/test_decision.py
+++ b/tests/test_reasoning/test_decision.py
@@ -186,6 +186,64 @@ class TestDecisionReasoning:
             ttl=3,
         )
 
+    def test_get_decision_prompt_without_optional_memory_methods(self, mock_agent):
+        mock_agent.memory = Mock(spec=[])
+
+        reasoning = DecisionReasoning(mock_agent)
+        obs = Observation(step=1, self_state={}, local_state={})
+
+        prompt_list = reasoning.get_decision_prompt(obs)
+
+        assert prompt_list == ["current observation: \n" + str(obs)]
+
+    def test_plan_uses_structured_response_when_available(
+        self, llm_response_factory, mock_agent
+    ):
+        mock_agent.memory = Mock()
+        mock_agent.memory.get_prompt_ready.return_value = "memory1"
+        mock_agent.memory.get_communication_history.return_value = ""
+        mock_agent.memory.add_to_memory = Mock()
+        mock_agent.llm = Mock()
+        mock_agent.tool_manager = Mock()
+        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent._step_display_data = {}
+
+        parsed_output = DecisionOutput(
+            goal="Reach food",
+            constraints=["One movement per turn"],
+            known_facts=["Food is visible nearby"],
+            unknowns=["Whether the route stays open"],
+            assumptions=["The route remains open this step"],
+            options=[
+                DecisionOption(
+                    name="move_to_food",
+                    description="Move toward visible food",
+                    tradeoffs=["Fast", "May be contested"],
+                    score=0.88,
+                )
+            ],
+            chosen_option="move_to_food",
+            rationale="It best advances the immediate goal.",
+            confidence=0.78,
+            risks=["Another agent may reach it first"],
+            next_action="move_to_food",
+        )
+        rsp = llm_response_factory(content="ignored")
+        rsp.choices[0].message.parsed = parsed_output
+        mock_agent.llm.generate.return_value = rsp
+
+        mock_plan = Plan(step=1, llm_plan=Mock())
+        reasoning = DecisionReasoning(mock_agent)
+        reasoning.execute_tool_call = Mock(return_value=mock_plan)
+
+        obs = Observation(step=1, self_state={}, local_state={})
+        result = reasoning.plan(obs=obs, prompt="Custom prompt")
+
+        assert result == mock_plan
+        mock_agent.memory.add_to_memory.assert_called_once_with(
+            type="decision", content=parsed_output.model_dump()
+        )
+
     def test_plan_no_prompt_error(self, mock_agent):
         mock_agent.step_prompt = None
         mock_agent.memory = Mock()

--- a/tests/test_reasoning/test_decision.py
+++ b/tests/test_reasoning/test_decision.py
@@ -282,7 +282,10 @@ class TestDecisionReasoning:
                             {
                                 "name": "move_east",
                                 "description": "Move one cell east",
-                                "tradeoffs": ["Improves coordination", "May increase exposure"],
+                                "tradeoffs": [
+                                    "Improves coordination",
+                                    "May increase exposure",
+                                ],
                                 "score": 0.74,
                             }
                         ],

--- a/tests/test_reasoning/test_decision.py
+++ b/tests/test_reasoning/test_decision.py
@@ -1,0 +1,271 @@
+import asyncio
+import json
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from mesa_llm.reasoning.decision import (
+    DecisionOption,
+    DecisionOutput,
+    DecisionReasoning,
+)
+from mesa_llm.reasoning.reasoning import Observation, Plan
+
+
+class TestDecisionModels:
+    def test_decision_option_creation(self):
+        option = DecisionOption(
+            name="move_to_market",
+            description="Move toward the market cell.",
+            tradeoffs=["Consumes one turn", "May expose the agent"],
+            score=0.82,
+        )
+
+        assert option.name == "move_to_market"
+        assert option.tradeoffs == ["Consumes one turn", "May expose the agent"]
+        assert option.score == 0.82
+
+    def test_decision_output_creation(self):
+        output = DecisionOutput(
+            goal="Reach a safer location",
+            constraints=["Can only move once"],
+            known_facts=["An exit is visible to the north"],
+            unknowns=["Whether another agent will block the path"],
+            assumptions=["The northern cell remains open this turn"],
+            options=[
+                DecisionOption(
+                    name="move_north",
+                    description="Move one cell north.",
+                    tradeoffs=["Fast", "Could enter conflict"],
+                    score=0.9,
+                )
+            ],
+            chosen_option="move_north",
+            rationale="It advances the goal with the best visible route.",
+            confidence=0.76,
+            risks=["The path could become blocked"],
+            next_action="move_north",
+        )
+
+        assert output.goal == "Reach a safer location"
+        assert output.chosen_option == "move_north"
+        assert output.confidence == 0.76
+        assert output.next_action == "move_north"
+
+
+class TestDecisionReasoning:
+    def test_decision_reasoning_initialization(self, mock_agent):
+        reasoning = DecisionReasoning(mock_agent)
+
+        assert reasoning.agent == mock_agent
+
+    def test_get_decision_system_prompt(self, mock_agent):
+        reasoning = DecisionReasoning(mock_agent)
+
+        prompt = reasoning.get_decision_system_prompt()
+
+        assert "strict JSON object" in prompt
+        assert "known_facts" in prompt
+        assert "next_action" in prompt
+
+    def test_get_decision_prompt_with_observation(self, mock_agent):
+        mock_agent.memory = Mock()
+        mock_agent.memory.get_prompt_ready.return_value = "memory1\n\nmemory2"
+        mock_agent.memory.get_communication_history.return_value = "communication"
+
+        reasoning = DecisionReasoning(mock_agent)
+        obs = Observation(step=1, self_state={}, local_state={})
+        prompt_list = reasoning.get_decision_prompt(obs)
+
+        assert len(prompt_list) >= 2
+        assert "last communication" in prompt_list[-2]
+        assert "current observation" in prompt_list[-1]
+
+    def test_plan_with_prompt(self, llm_response_factory, mock_agent):
+        mock_agent.memory = Mock()
+        mock_agent.memory.get_prompt_ready.return_value = "memory1"
+        mock_agent.memory.get_communication_history.return_value = ""
+        mock_agent.memory.add_to_memory = Mock()
+        mock_agent.llm = Mock()
+        mock_agent.tool_manager = Mock()
+        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent._step_display_data = {}
+
+        mock_agent.llm.generate.return_value = llm_response_factory(
+            content=json.dumps(
+                {
+                    "goal": "Reach food",
+                    "constraints": ["One movement per turn"],
+                    "known_facts": ["Food is visible nearby"],
+                    "unknowns": ["Whether the route stays open"],
+                    "assumptions": ["The route remains open this step"],
+                    "options": [
+                        {
+                            "name": "move_to_food",
+                            "description": "Move toward visible food",
+                            "tradeoffs": ["Fast", "May be contested"],
+                            "score": 0.88,
+                        }
+                    ],
+                    "chosen_option": "move_to_food",
+                    "rationale": "It best advances the immediate goal.",
+                    "confidence": 0.78,
+                    "risks": ["Another agent may reach it first"],
+                    "next_action": "move_to_food",
+                }
+            )
+        )
+
+        mock_plan = Plan(step=1, llm_plan=Mock())
+        reasoning = DecisionReasoning(mock_agent)
+        reasoning.execute_tool_call = Mock(return_value=mock_plan)
+
+        obs = Observation(step=1, self_state={}, local_state={})
+        result = reasoning.plan(obs=obs, prompt="Custom prompt")
+
+        assert result == mock_plan
+        mock_agent.memory.add_to_memory.assert_called_once()
+        reasoning.execute_tool_call.assert_called_once_with(
+            "move_to_food",
+            selected_tools=None,
+            ttl=1,
+        )
+        assert mock_agent._step_display_data["plan_content"] == (
+            "It best advances the immediate goal."
+        )
+
+    def test_plan_with_selected_tools(self, llm_response_factory, mock_agent):
+        mock_agent.step_prompt = "Default step prompt"
+        mock_agent.memory = Mock()
+        mock_agent.memory.get_prompt_ready.return_value = "memory1"
+        mock_agent.memory.get_communication_history.return_value = ""
+        mock_agent.memory.add_to_memory = Mock()
+        mock_agent.llm = Mock()
+        mock_agent.tool_manager = Mock()
+        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent._step_display_data = {}
+
+        mock_agent.llm.generate.return_value = llm_response_factory(
+            content=json.dumps(
+                {
+                    "goal": "Hold position",
+                    "constraints": ["No safe exit visible"],
+                    "known_facts": ["A threat is adjacent"],
+                    "unknowns": ["Threat intent"],
+                    "assumptions": ["Staying still is safer than moving blindly"],
+                    "options": [
+                        {
+                            "name": "wait",
+                            "description": "Hold current position",
+                            "tradeoffs": ["No progress", "Reduces exposure"],
+                            "score": 0.61,
+                        }
+                    ],
+                    "chosen_option": "wait",
+                    "rationale": "It minimizes immediate danger.",
+                    "confidence": 0.53,
+                    "risks": ["Threat may approach anyway"],
+                    "next_action": "wait",
+                }
+            )
+        )
+
+        mock_plan = Plan(step=1, llm_plan=Mock())
+        reasoning = DecisionReasoning(mock_agent)
+        reasoning.execute_tool_call = Mock(return_value=mock_plan)
+
+        obs = Observation(step=1, self_state={}, local_state={})
+        selected_tools = ["tool1", "tool2"]
+        result = reasoning.plan(obs=obs, ttl=3, selected_tools=selected_tools)
+
+        assert result == mock_plan
+        mock_agent.tool_manager.get_all_tools_schema.assert_called_with(selected_tools)
+        reasoning.execute_tool_call.assert_called_once_with(
+            "wait",
+            selected_tools=selected_tools,
+            ttl=3,
+        )
+
+    def test_plan_no_prompt_error(self, mock_agent):
+        mock_agent.step_prompt = None
+        mock_agent.memory = Mock()
+        mock_agent.memory.get_prompt_ready.return_value = "memory1"
+        mock_agent.memory.get_communication_history.return_value = ""
+
+        reasoning = DecisionReasoning(mock_agent)
+        obs = Observation(step=1, self_state={}, local_state={})
+
+        with pytest.raises(
+            ValueError, match=r"No prompt provided and agent.step_prompt is None"
+        ):
+            reasoning.plan(obs=obs)
+
+    def test_aplan_async_version(self, llm_response_factory, mock_agent):
+        mock_agent.step_prompt = "Default step prompt"
+        mock_agent.memory = Mock()
+        mock_agent.memory.get_prompt_ready.return_value = "memory1"
+        mock_agent.memory.get_communication_history.return_value = ""
+        mock_agent.memory.aadd_to_memory = AsyncMock()
+        mock_agent.llm = Mock()
+        mock_agent.tool_manager = Mock()
+        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent._step_display_data = {}
+
+        mock_agent.llm.agenerate = AsyncMock(
+            return_value=llm_response_factory(
+                content=json.dumps(
+                    {
+                        "goal": "Move closer to ally",
+                        "constraints": ["One step per turn"],
+                        "known_facts": ["An ally is east of the agent"],
+                        "unknowns": ["Whether the east cell is contested"],
+                        "assumptions": ["The ally remains in place this step"],
+                        "options": [
+                            {
+                                "name": "move_east",
+                                "description": "Move one cell east",
+                                "tradeoffs": ["Improves coordination", "May increase exposure"],
+                                "score": 0.74,
+                            }
+                        ],
+                        "chosen_option": "move_east",
+                        "rationale": "It improves coordination with acceptable risk.",
+                        "confidence": 0.69,
+                        "risks": ["The east cell may be occupied"],
+                        "next_action": "move_east",
+                    }
+                )
+            )
+        )
+
+        mock_plan = Plan(step=1, llm_plan=Mock())
+        reasoning = DecisionReasoning(mock_agent)
+        reasoning.aexecute_tool_call = AsyncMock(return_value=mock_plan)
+
+        obs = Observation(step=1, self_state={}, local_state={})
+        result = asyncio.run(reasoning.aplan(obs=obs, ttl=4))
+
+        assert result == mock_plan
+        mock_agent.llm.agenerate.assert_called_once()
+        reasoning.aexecute_tool_call.assert_awaited_once_with(
+            "move_east",
+            selected_tools=None,
+            ttl=4,
+        )
+        assert mock_agent._step_display_data["plan_content"] == (
+            "It improves coordination with acceptable risk."
+        )
+
+    def test_aplan_no_prompt_error(self, mock_agent):
+        mock_agent.step_prompt = None
+        mock_agent.memory = Mock()
+        mock_agent.memory.get_prompt_ready.return_value = "memory1"
+        mock_agent.memory.get_communication_history.return_value = ""
+
+        reasoning = DecisionReasoning(mock_agent)
+        obs = Observation(step=1, self_state={}, local_state={})
+
+        with pytest.raises(
+            ValueError, match=r"No prompt provided and agent.step_prompt is None"
+        ):
+            asyncio.run(reasoning.aplan(obs=obs))

--- a/tests/test_reasoning/test_decision.py
+++ b/tests/test_reasoning/test_decision.py
@@ -25,6 +25,15 @@ class TestDecisionModels:
         assert option.tradeoffs == ["Consumes one turn", "May expose the agent"]
         assert option.score == 0.82
 
+    def test_decision_option_score_constraints(self):
+        with pytest.raises(ValueError):
+            DecisionOption(
+                name="invalid_option",
+                description="Invalid score",
+                tradeoffs=["Not allowed"],
+                score=1.5,
+            )
+
     def test_decision_output_creation(self):
         output = DecisionOutput(
             goal="Reach a safer location",
@@ -87,6 +96,27 @@ class TestDecisionReasoning:
         mock_agent.memory.get_communication_history.return_value = ""
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.llm = Mock()
+        parsed_output = DecisionOutput(
+            goal="Reach food",
+            constraints=["One movement per turn"],
+            known_facts=["Food is visible nearby"],
+            unknowns=["Whether the route stays open"],
+            assumptions=["The route remains open this step"],
+            options=[
+                DecisionOption(
+                    name="move_to_food",
+                    description="Move toward visible food",
+                    tradeoffs=["Fast", "May be contested"],
+                    score=0.88,
+                )
+            ],
+            chosen_option="move_to_food",
+            rationale="It best advances the immediate goal.",
+            confidence=0.78,
+            risks=["Another agent may reach it first"],
+            next_action="move_to_food",
+        )
+        mock_agent.llm.parse_structured_output.return_value = parsed_output
         mock_agent.tool_manager = Mock()
         mock_agent.tool_manager.get_all_tools_schema.return_value = {}
         mock_agent._step_display_data = {}
@@ -125,6 +155,14 @@ class TestDecisionReasoning:
 
         assert result == mock_plan
         mock_agent.memory.add_to_memory.assert_called_once()
+        mock_agent.llm.generate.assert_called_once()
+        assert (
+            mock_agent.llm.generate.call_args.kwargs["system_prompt"]
+            == reasoning.get_decision_system_prompt()
+        )
+        mock_agent.llm.parse_structured_output.assert_called_once_with(
+            mock_agent.llm.generate.return_value, DecisionOutput
+        )
         reasoning.execute_tool_call.assert_called_once_with(
             "move_to_food",
             selected_tools=None,
@@ -141,6 +179,26 @@ class TestDecisionReasoning:
         mock_agent.memory.get_communication_history.return_value = ""
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.llm = Mock()
+        mock_agent.llm.parse_structured_output.return_value = DecisionOutput(
+            goal="Hold position",
+            constraints=["No safe exit visible"],
+            known_facts=["A threat is adjacent"],
+            unknowns=["Threat intent"],
+            assumptions=["Staying still is safer than moving blindly"],
+            options=[
+                DecisionOption(
+                    name="wait",
+                    description="Hold current position",
+                    tradeoffs=["No progress", "Reduces exposure"],
+                    score=0.61,
+                )
+            ],
+            chosen_option="wait",
+            rationale="It minimizes immediate danger.",
+            confidence=0.53,
+            risks=["Threat may approach anyway"],
+            next_action="wait",
+        )
         mock_agent.tool_manager = Mock()
         mock_agent.tool_manager.get_all_tools_schema.return_value = {}
         mock_agent._step_display_data = {}
@@ -196,7 +254,7 @@ class TestDecisionReasoning:
 
         assert prompt_list == ["current observation: \n" + str(obs)]
 
-    def test_plan_uses_structured_response_when_available(
+    def test_plan_uses_structured_response_normalizer(
         self, llm_response_factory, mock_agent
     ):
         mock_agent.memory = Mock()
@@ -204,10 +262,6 @@ class TestDecisionReasoning:
         mock_agent.memory.get_communication_history.return_value = ""
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.llm = Mock()
-        mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
-        mock_agent._step_display_data = {}
-
         parsed_output = DecisionOutput(
             goal="Reach food",
             constraints=["One movement per turn"],
@@ -228,9 +282,11 @@ class TestDecisionReasoning:
             risks=["Another agent may reach it first"],
             next_action="move_to_food",
         )
-        rsp = llm_response_factory(content="ignored")
-        rsp.choices[0].message.parsed = parsed_output
-        mock_agent.llm.generate.return_value = rsp
+        mock_agent.llm.parse_structured_output.return_value = parsed_output
+        mock_agent.tool_manager = Mock()
+        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent._step_display_data = {}
+        mock_agent.llm.generate.return_value = llm_response_factory(content="ignored")
 
         mock_plan = Plan(step=1, llm_plan=Mock())
         reasoning = DecisionReasoning(mock_agent)
@@ -242,6 +298,9 @@ class TestDecisionReasoning:
         assert result == mock_plan
         mock_agent.memory.add_to_memory.assert_called_once_with(
             type="decision", content=parsed_output.model_dump()
+        )
+        mock_agent.llm.parse_structured_output.assert_called_once_with(
+            mock_agent.llm.generate.return_value, DecisionOutput
         )
 
     def test_plan_no_prompt_error(self, mock_agent):
@@ -265,6 +324,26 @@ class TestDecisionReasoning:
         mock_agent.memory.get_communication_history.return_value = ""
         mock_agent.memory.aadd_to_memory = AsyncMock()
         mock_agent.llm = Mock()
+        mock_agent.llm.parse_structured_output.return_value = DecisionOutput(
+            goal="Move closer to ally",
+            constraints=["One step per turn"],
+            known_facts=["An ally is east of the agent"],
+            unknowns=["Whether the east cell is contested"],
+            assumptions=["The ally remains in place this step"],
+            options=[
+                DecisionOption(
+                    name="move_east",
+                    description="Move one cell east",
+                    tradeoffs=["Improves coordination", "May increase exposure"],
+                    score=0.74,
+                )
+            ],
+            chosen_option="move_east",
+            rationale="It improves coordination with acceptable risk.",
+            confidence=0.69,
+            risks=["The east cell may be occupied"],
+            next_action="move_east",
+        )
         mock_agent.tool_manager = Mock()
         mock_agent.tool_manager.get_all_tools_schema.return_value = {}
         mock_agent._step_display_data = {}
@@ -305,6 +384,13 @@ class TestDecisionReasoning:
 
         assert result == mock_plan
         mock_agent.llm.agenerate.assert_called_once()
+        assert (
+            mock_agent.llm.agenerate.call_args.kwargs["system_prompt"]
+            == reasoning.get_decision_system_prompt()
+        )
+        mock_agent.llm.parse_structured_output.assert_called_once_with(
+            mock_agent.llm.agenerate.return_value, DecisionOutput
+        )
         reasoning.aexecute_tool_call.assert_awaited_once_with(
             "move_east",
             selected_tools=None,


### PR DESCRIPTION
## Summary

This PR adds a new structured reasoning strategy, `DecisionReasoning`, on the `cot` branch.

The change does not modify the existing `CoTReasoning` implementation. Instead, it introduces a separate reasoning module for cases where the model should make decisions through a strict, machine-readable schema rather than free-form chain-of-thought text.

The new reasoning path:
- gathers memory and observation context
- asks the LLM for a structured decision object
- validates that object with Pydantic
- stores the structured decision in memory
- executes only the selected `next_action`

## What This PR Adds

### New reasoning module

Added:

- `mesa_llm/reasoning/decision.py`

This module defines:
- `DecisionOption`
- `DecisionOutput`
- `DecisionReasoning`

### New reasoning schema

The model is required to return a strict JSON object containing:

- `goal`
- `constraints`
- `known_facts`
- `unknowns`
- `assumptions`
- `options`
- `chosen_option`
- `rationale`
- `confidence`
- `risks`
- `next_action`

Each option also contains:
- `name`
- `description`
- `tradeoffs`
- `score`

### Validation

The structured response is validated through Pydantic before execution.

This gives:
- a stable output shape
- explicit required fields
- bounded `confidence` in the range `0.0` to `1.0`
- safer downstream use of model output

### Execution flow

The existing tool execution pipeline is preserved.

The flow is now:

1. Build prompt context from memory and current observation
2. Generate a structured decision object
3. Store the decision as memory
4. Extract `next_action`
5. Execute `next_action` through the existing tool executor

This means the executor no longer depends on a long reasoning blob for this reasoning mode.

### Memory integration

The decision artifact is stored as:

- `type="decision"`

This makes the reasoning result easier to inspect and supports future analysis of:
- confidence
- risks
- assumptions
- option selection quality

### Tests

Added:

- `tests/test_reasoning/test_decision.py`

The test coverage includes:
- schema model creation
- prompt generation
- sync planning
- async planning
- selected tool propagation
- prompt fallback behavior
- no-prompt error handling
- execution of `next_action`
- display metadata behavior

## What This PR Does Not Change

This PR does **not** modify:
- `mesa_llm/reasoning/cot.py`
- `CoTReasoning`
- `ReActReasoning`
- `ReWOOReasoning`

So while this branch is named `cot`, the latest change is not an update to the existing CoT implementation. It is a new alternative reasoning mode focused on structured decision-making.

## Why This Change

The current reasoning styles in the repo support:
- free-form chain-of-thought
- lightweight reasoning + action
- multi-step planning

What was missing was a reasoning mode that explicitly separates:
- facts
- unknowns
- assumptions
- options
- tradeoffs
- confidence
- risks
- final executable action

This is useful when decision quality and inspectability matter more than verbose reasoning prose.

## Example Output

```json
{
  "goal": "Reach food",
  "constraints": ["One move this turn"],
  "known_facts": ["Food is visible to the east"],
  "unknowns": ["Whether another agent will block the path"],
  "assumptions": ["The east cell remains traversable this step"],
  "options": [
    {
      "name": "move_east",
      "description": "Move toward visible food",
      "tradeoffs": ["Fast progress", "Potential contention"],
      "score": 0.88
    }
  ],
  "chosen_option": "move_east",
  "rationale": "It best advances the goal with acceptable risk.",
  "confidence": 0.78,
  "risks": ["Another agent may reach the food first"],
  "next_action": "move_east"
}
```

Only `next_action` is forwarded to the executor.

## Validation Performed
The following checks were run:
```python
pytest tests/test_reasoning/test_decision.py tests/test_reasoning -q
ruff check mesa_llm tests
```
Results:

`reasoning tests passed`

Ruff : `passed`

only an existing upstream Mesa deprecation warning was observed during pytest

Files Added : 
`mesa_llm/reasoning/decision.py
tests/test_reasoning/test_decision.py`

## Notes For Reviewers
This PR should be reviewed as:

- a new reasoning capability

- a structured alternative to free-form CoT

- a non-breaking addition to the current reasoning system


#### It should not be interpreted as an enhancement to the existing CoTReasoning class itself.


