### PR TITLE
Feat: Add Long-Term Memory Compression/Pruning to STLTMemory via character bounds

### DIFF
--- a/mesa_llm/memory/st_lt_memory.py
+++ b/mesa_llm/memory/st_lt_memory.py
@@ -75,7 +75,7 @@ class STLTMemory(Memory):
             You are a helpful assistant that compresses excessively long text memories.
             The following text represents an agent's long-term memory. It has grown too large.
             Please compress it, retaining only the most critical overarching facts and lessons, and discarding less salient or outdated details.
-            
+
             Current Long-term memory to prune:
             {long_term_memory}
             """

--- a/tests/test_memory/test_STLT_memory.py
+++ b/tests/test_memory/test_STLT_memory.py
@@ -147,9 +147,9 @@ class TestSTLTMemory:
 
         memory._update_long_term_memory()
 
-        assert isinstance(
-            memory.long_term_memory, str
-        ), "long_term_memory must be a string, not a ModelResponse object"
+        assert isinstance(memory.long_term_memory, str), (
+            "long_term_memory must be a string, not a ModelResponse object"
+        )
         assert memory.long_term_memory == "This is the summary text"
 
     def test_observation_tracking(self, mock_agent):
@@ -181,9 +181,9 @@ class TestSTLTMemory:
 
         result = memory.get_prompt_ready()
 
-        assert isinstance(
-            result, str
-        ), f"get_prompt_ready() must return str, got {type(result).__name__}"
+        assert isinstance(result, str), (
+            f"get_prompt_ready() must return str, got {type(result).__name__}"
+        )
         assert "Short term memory:" in result
         assert "Long term memory:" in result
         assert "Test obs" in result
@@ -195,9 +195,9 @@ class TestSTLTMemory:
 
         result = memory.get_prompt_ready()
 
-        assert isinstance(
-            result, str
-        ), f"get_prompt_ready() must return str, got {type(result).__name__}"
+        assert isinstance(result, str), (
+            f"get_prompt_ready() must return str, got {type(result).__name__}"
+        )
         assert "Short term memory:" in result
         assert "Long term memory:" in result
 
@@ -233,9 +233,9 @@ class TestSTLTMemory:
         call_args = mock_llm.generate.call_args[0][0]
 
         # The oldest entry MUST be in the prompt sent to the LLM
-        assert (
-            "critical event at step 0" in call_args
-        ), "Oldest memory entry was silently dropped before consolidation!"
+        assert "critical event at step 0" in call_args, (
+            "Oldest memory entry was silently dropped before consolidation!"
+        )
 
     def test_memory_pops_and_summarizes_exact_k_items(
         self, mock_agent, mock_llm, llm_response_factory
@@ -339,7 +339,6 @@ class TestSTLTMemory:
         """
         Verify that _aprune_long_term_memory behaves the same asynchronously
         """
-        import asyncio
 
         async def mock_agenerate(prompt):
             if "compresses excessively long text memories" in prompt:


### PR DESCRIPTION
## Description
This PR addresses the "Memory Decay & Salience Pruning" proposed feature for `STLTMemory`.

Currently, `STLTMemory` operates such that older items are consolidated and replace the `long_term_memory` string. However, over thousands of steps, the LLM continues to update and include new information. Even with full replacement, this natural tendency of the LLM to retain details causes the long-term string to expand indefinitely, eventually breaching context limits and inflating token processing costs.

This PR introduces a `long_term_char_limit` configuration bounds. If the `long_term_memory` string exceeds this character count after a short-term consolidation, the `STLTMemory` module will trigger a `pruning_prompt` instruction, forcing the LLM to compress the current `long_term_memory` by extracting the overall salient facts and discarding older, less-relevant information. 

## Changes
- Modified `st_lt_memory.py`: Added `long_term_char_limit` to `__init__` and integrated `_prune_long_term_memory` / `_aprune_long_term_memory` triggers after every long-term memory update.
- Updated `STLTMemory` prompts with a new `pruning_prompt` string payload explicitly demanding text-size compression architectures.
- Appended multiple unit tests within `tests/test_memory/test_STLT_memory.py` assessing `long_term_char_limit` threshold breaches and valid secondary LLM consolidation-calls.

## Related Tickets
Closes #214
