### PR TITLE
fix: add resilient parallel execution with per-agent error isolation

### DIFF
--- a/mesa_llm/__init__.py
+++ b/mesa_llm/__init__.py
@@ -3,6 +3,7 @@ import datetime
 import mesa_llm.tools.inbuilt_tools  # noqa: F401, to register inbuilt tools
 
 from .parallel_stepping import (
+    AgentStepResult,
     enable_automatic_parallel_stepping,
     step_agents_parallel,
     step_agents_parallel_sync,
@@ -15,6 +16,7 @@ from .tools.tool_manager import ToolManager
 enable_automatic_parallel_stepping()
 
 __all__ = [
+    "AgentStepResult",
     "Observation",
     "Plan",
     "ToolManager",

--- a/mesa_llm/parallel_stepping.py
+++ b/mesa_llm/parallel_stepping.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import logging
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from mesa.agent import Agent, AgentSet
@@ -19,16 +20,63 @@ logger = logging.getLogger(__name__)
 # Global variable to control parallel stepping mode
 _PARALLEL_STEPPING_MODE = "asyncio"  # or "threading"
 
+_PARALLEL_ON_ERROR = "continue"  # "continue" | "raise"
+_PARALLEL_TIMEOUT: float | None = None
 
-async def step_agents_parallel(agents: list[Agent | LLMAgent]) -> None:
-    """Step all agents in parallel using async/await."""
-    tasks = []
+
+@dataclass
+class AgentStepResult:
+    """Result of a single agent's step during parallel execution."""
+
+    agent: Agent | LLMAgent
+    success: bool
+    exception: BaseException | None = None
+
+
+async def step_agents_parallel(
+    agents: list[Agent | LLMAgent],
+    *,
+    on_error: str | None = None,
+    timeout: float | None = None,
+) -> list[AgentStepResult]:
+    """Step all agents in parallel using async/await with error isolation."""
+    effective_on_error = on_error if on_error is not None else _PARALLEL_ON_ERROR
+    effective_timeout = timeout if timeout is not None else _PARALLEL_TIMEOUT
+
+    coros = []
+    agent_list = []
     for agent in agents:
         if hasattr(agent, "astep"):
-            tasks.append(agent.astep())
+            coro = agent.astep()
         elif hasattr(agent, "step"):
-            tasks.append(_sync_step(agent))
-    await asyncio.gather(*tasks)
+            coro = _sync_step(agent)
+        else:
+            continue
+        if effective_timeout is not None:
+            coro = asyncio.wait_for(coro, timeout=effective_timeout)
+        coros.append(coro)
+        agent_list.append(agent)
+
+    outcomes = await asyncio.gather(*coros, return_exceptions=True)
+
+    results = []
+    for agent, outcome in zip(agent_list, outcomes):
+        if isinstance(outcome, BaseException):
+            logger.error(
+                "Agent %s (id=%s) failed during parallel step: %s",
+                agent.__class__.__name__,
+                getattr(agent, "unique_id", "?"),
+                outcome,
+            )
+            results.append(
+                AgentStepResult(agent=agent, success=False, exception=outcome)
+            )
+            if effective_on_error == "raise":
+                raise outcome
+        else:
+            results.append(AgentStepResult(agent=agent, success=True))
+
+    return results
 
 
 async def _sync_step(agent: Agent) -> None:
@@ -36,39 +84,70 @@ async def _sync_step(agent: Agent) -> None:
     agent.step()
 
 
-def step_agents_multithreaded(agents: list[Agent | LLMAgent]) -> None:
-    """Step all agents in parallel using threads."""
+def step_agents_multithreaded(
+    agents: list[Agent | LLMAgent],
+    *,
+    on_error: str | None = None,
+    timeout: float | None = None,
+) -> list[AgentStepResult]:
+    """Step all agents in parallel using threads with error isolation."""
+    effective_on_error = on_error if on_error is not None else _PARALLEL_ON_ERROR
+    effective_timeout = timeout if timeout is not None else _PARALLEL_TIMEOUT
+
+    results = []
     with concurrent.futures.ThreadPoolExecutor() as executor:
-        futures = []
+        agent_futures = []
         for agent in agents:
             if hasattr(agent, "astep"):
-                # run async steps in the event loop in a thread
-                futures.append(
-                    executor.submit(lambda agent=agent: asyncio.run(agent.astep()))
-                )
+                future = executor.submit(lambda agent=agent: asyncio.run(agent.astep()))
             elif hasattr(agent, "step"):
-                futures.append(executor.submit(agent.step))
+                future = executor.submit(agent.step)
+            else:
+                continue
+            agent_futures.append((agent, future))
 
-        for future in futures:
-            future.result()
+        for agent, future in agent_futures:
+            try:
+                future.result(timeout=effective_timeout)
+                results.append(AgentStepResult(agent=agent, success=True))
+            except Exception as exc:
+                logger.error(
+                    "Agent %s (id=%s) failed during threaded step: %s",
+                    agent.__class__.__name__,
+                    getattr(agent, "unique_id", "?"),
+                    exc,
+                )
+                results.append(
+                    AgentStepResult(agent=agent, success=False, exception=exc)
+                )
+                if effective_on_error == "raise":
+                    raise
+    return results
 
 
-def step_agents_parallel_sync(agents: list[Agent | LLMAgent]) -> None:
+def step_agents_parallel_sync(
+    agents: list[Agent | LLMAgent],
+    *,
+    on_error: str | None = None,
+    timeout: float | None = None,
+) -> list[AgentStepResult]:
     """Synchronous wrapper for parallel stepping using the global mode."""
     if _PARALLEL_STEPPING_MODE == "asyncio":
         try:
             asyncio.get_running_loop()
-            # If in event loop, use thread
             with concurrent.futures.ThreadPoolExecutor() as executor:
                 future = executor.submit(
-                    lambda: asyncio.run(step_agents_parallel(agents))
+                    lambda: asyncio.run(
+                        step_agents_parallel(agents, on_error=on_error, timeout=timeout)
+                    )
                 )
-                future.result()
+                return future.result()
         except RuntimeError:
-            # No event loop - create one
-            asyncio.run(step_agents_parallel(agents))
+            return asyncio.run(
+                step_agents_parallel(agents, on_error=on_error, timeout=timeout)
+            )
     elif _PARALLEL_STEPPING_MODE == "threading":
-        step_agents_multithreaded(agents)
+        return step_agents_multithreaded(agents, on_error=on_error, timeout=timeout)
     else:
         raise ValueError(f"Unknown parallel stepping mode: {_PARALLEL_STEPPING_MODE}")
 
@@ -87,18 +166,30 @@ def _enhanced_shuffle_do(self, method: str, *args, **kwargs):
     _original_shuffle_do(self, method, *args, **kwargs)
 
 
-def enable_automatic_parallel_stepping(mode: str = "asyncio"):
-    """Enable automatic parallel stepping with selectable mode ('asyncio' or 'threading')."""
-    global _PARALLEL_STEPPING_MODE  # noqa: PLW0603
+def enable_automatic_parallel_stepping(
+    mode: str = "asyncio",
+    *,
+    on_error: str = "continue",
+    timeout: float | None = None,
+):
+    """Enable automatic parallel stepping with selectable mode and error handling."""
+    global _PARALLEL_STEPPING_MODE, _PARALLEL_ON_ERROR, _PARALLEL_TIMEOUT  # noqa: PLW0603
     if mode not in ("asyncio", "threading"):
         raise ValueError("mode must be either 'asyncio' or 'threading'")
+    if on_error not in ("continue", "raise"):
+        raise ValueError("on_error must be either 'continue' or 'raise'")
     _PARALLEL_STEPPING_MODE = mode
+    _PARALLEL_ON_ERROR = on_error
+    _PARALLEL_TIMEOUT = timeout
     AgentSet.shuffle_do = _enhanced_shuffle_do
 
 
 def disable_automatic_parallel_stepping():
-    """Restore original shuffle_do behavior."""
+    """Restore original shuffle_do behavior and reset config."""
+    global _PARALLEL_ON_ERROR, _PARALLEL_TIMEOUT  # noqa: PLW0603
     AgentSet.shuffle_do = _original_shuffle_do
+    _PARALLEL_ON_ERROR = "continue"
+    _PARALLEL_TIMEOUT = None
 
 
 # --- Monkey-patch AgentSet with do_async for async parallel method calls ---
@@ -121,7 +212,17 @@ def _agentset_do_async(self, method: str, *args, **kwargs):
                 raise AttributeError(
                     f"Agent {agent} does not have async method '{method}'"
                 )
-        return await asyncio.gather(*tasks)
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        for agent, result in zip(self, results):
+            if isinstance(result, BaseException):
+                logger.error(
+                    "Agent %s (id=%s) failed during do_async('%s'): %s",
+                    agent.__class__.__name__,
+                    getattr(agent, "unique_id", "?"),
+                    method,
+                    result,
+                )
+        return results
 
     return _run()
 

--- a/tests/test_parallel_error_handling.py
+++ b/tests/test_parallel_error_handling.py
@@ -1,0 +1,224 @@
+import asyncio
+
+import pytest
+from mesa.agent import Agent, AgentSet
+from mesa.model import Model
+
+from mesa_llm.parallel_stepping import (
+    AgentStepResult,
+    disable_automatic_parallel_stepping,
+    enable_automatic_parallel_stepping,
+    step_agents_multithreaded,
+    step_agents_parallel,
+    step_agents_parallel_sync,
+)
+
+
+class DummyModel(Model):
+    def __init__(self):
+        super().__init__(seed=42)
+        self.parallel_stepping = False
+
+
+class SyncAgent(Agent):
+    def __init__(self, model):
+        super().__init__(model)
+        self.counter = 0
+
+    def step(self):
+        self.counter += 1
+
+
+class AsyncAgent(Agent):
+    def __init__(self, model):
+        super().__init__(model)
+        self.counter = 0
+
+    async def astep(self):
+        self.counter += 1
+
+
+class FailingAsyncAgent(Agent):
+    def __init__(self, model):
+        super().__init__(model)
+
+    async def astep(self):
+        raise RuntimeError("LLM timeout")
+
+
+class FailingSyncAgent(Agent):
+    def __init__(self, model):
+        super().__init__(model)
+
+    def step(self):
+        raise ValueError("bad response")
+
+
+class SlowAsyncAgent(Agent):
+    def __init__(self, model):
+        super().__init__(model)
+        self.counter = 0
+
+    async def astep(self):
+        await asyncio.sleep(10)
+        self.counter += 1
+
+
+# --- Async path tests ---
+
+
+@pytest.mark.asyncio
+async def test_parallel_all_succeed_returns_results():
+    m = DummyModel()
+    a1 = AsyncAgent(m)
+    a2 = SyncAgent(m)
+    results = await step_agents_parallel([a1, a2])
+    assert len(results) == 2
+    assert all(isinstance(r, AgentStepResult) for r in results)
+    assert all(r.success for r in results)
+    assert all(r.exception is None for r in results)
+    assert a1.counter == 1
+    assert a2.counter == 1
+
+
+@pytest.mark.asyncio
+async def test_parallel_one_fails_others_continue():
+    m = DummyModel()
+    good = AsyncAgent(m)
+    bad = FailingAsyncAgent(m)
+    results = await step_agents_parallel([bad, good])
+    assert good.counter == 1
+    failed = [r for r in results if not r.success]
+    succeeded = [r for r in results if r.success]
+    assert len(failed) == 1
+    assert len(succeeded) == 1
+    assert isinstance(failed[0].exception, RuntimeError)
+    assert failed[0].agent is bad
+
+
+@pytest.mark.asyncio
+async def test_parallel_on_error_raise():
+    m = DummyModel()
+    good = AsyncAgent(m)
+    bad = FailingAsyncAgent(m)
+    with pytest.raises(RuntimeError, match="LLM timeout"):
+        await step_agents_parallel([bad, good], on_error="raise")
+
+
+def test_parallel_on_error_invalid_value():
+    with pytest.raises(ValueError, match="on_error"):
+        enable_automatic_parallel_stepping(on_error="ignore")
+
+
+@pytest.mark.asyncio
+async def test_parallel_timeout_slow_agent():
+    m = DummyModel()
+    fast = AsyncAgent(m)
+    slow = SlowAsyncAgent(m)
+    results = await step_agents_parallel([slow, fast], timeout=0.1)
+    assert fast.counter == 1
+    assert slow.counter == 0
+    failed = [r for r in results if not r.success]
+    assert len(failed) == 1
+    assert isinstance(failed[0].exception, asyncio.TimeoutError)
+
+
+@pytest.mark.asyncio
+async def test_parallel_no_timeout_all_complete():
+    m = DummyModel()
+    a1 = AsyncAgent(m)
+    a2 = AsyncAgent(m)
+    results = await step_agents_parallel([a1, a2], timeout=5.0)
+    assert all(r.success for r in results)
+    assert a1.counter == 1
+    assert a2.counter == 1
+
+
+# --- Threaded path tests ---
+
+
+def test_threaded_one_fails_others_continue():
+    m = DummyModel()
+    good = AsyncAgent(m)
+    bad = FailingAsyncAgent(m)
+    results = step_agents_multithreaded([bad, good])
+    assert good.counter == 1
+    failed = [r for r in results if not r.success]
+    succeeded = [r for r in results if r.success]
+    assert len(failed) == 1
+    assert len(succeeded) == 1
+    assert isinstance(failed[0].exception, RuntimeError)
+
+
+def test_threaded_on_error_raise():
+    m = DummyModel()
+    good = AsyncAgent(m)
+    bad = FailingAsyncAgent(m)
+    with pytest.raises(RuntimeError, match="LLM timeout"):
+        step_agents_multithreaded([bad, good], on_error="raise")
+
+
+def test_threaded_timeout():
+    m = DummyModel()
+    fast = SyncAgent(m)
+    slow = SlowAsyncAgent(m)
+    results = step_agents_multithreaded([slow, fast], timeout=0.1)
+    assert fast.counter == 1
+    failed = [r for r in results if not r.success]
+    assert len(failed) == 1
+
+
+# --- Sync wrapper tests ---
+
+
+def test_sync_wrapper_forwards_params():
+    m = DummyModel()
+    good = AsyncAgent(m)
+    bad = FailingAsyncAgent(m)
+    results = step_agents_parallel_sync([bad, good], on_error="continue")
+    assert good.counter == 1
+    failed = [r for r in results if not r.success]
+    assert len(failed) == 1
+    assert isinstance(failed[0].exception, RuntimeError)
+
+
+# --- do_async tests ---
+
+
+@pytest.mark.asyncio
+async def test_do_async_one_fails_others_continue():
+    m = DummyModel()
+    good = AsyncAgent(m)
+    bad = FailingAsyncAgent(m)
+    agents = AgentSet([bad, good], random=m.random)
+    results = await agents.do_async("astep")
+    assert good.counter == 1
+    exceptions = [r for r in results if isinstance(r, BaseException)]
+    assert len(exceptions) == 1
+    assert isinstance(exceptions[0], RuntimeError)
+
+
+# --- Config tests ---
+
+
+def test_enable_config_sets_globals():
+    import mesa_llm.parallel_stepping as ps
+
+    enable_automatic_parallel_stepping(on_error="raise", timeout=5.0)
+    assert ps._PARALLEL_ON_ERROR == "raise"
+    assert ps._PARALLEL_TIMEOUT == 5.0
+
+    disable_automatic_parallel_stepping()
+    assert ps._PARALLEL_ON_ERROR == "continue"
+    assert ps._PARALLEL_TIMEOUT is None
+
+
+def test_backward_compat_no_params():
+    m = DummyModel()
+    a1 = AsyncAgent(m)
+    a2 = SyncAgent(m)
+    results = step_agents_parallel_sync([a1, a2])
+    assert a1.counter == 1
+    assert a2.counter == 1
+    assert len(results) == 2
+    assert all(r.success for r in results)

--- a/tests/test_parallel_error_handling.py
+++ b/tests/test_parallel_error_handling.py
@@ -222,3 +222,45 @@ def test_backward_compat_no_params():
     assert a2.counter == 1
     assert len(results) == 2
     assert all(r.success for r in results)
+
+
+# --- Coverage gap tests ---
+
+
+class _Bare:
+    """Object with neither step() nor astep() — should be skipped."""
+
+    pass
+
+
+@pytest.mark.asyncio
+async def test_parallel_skips_agent_without_step_or_astep():
+    m = DummyModel()
+    good = AsyncAgent(m)
+    noop = _Bare()
+    results = await step_agents_parallel([noop, good])
+    assert len(results) == 1
+    assert results[0].success
+    assert good.counter == 1
+
+
+def test_threaded_skips_agent_without_step_or_astep():
+    m = DummyModel()
+    good = SyncAgent(m)
+    noop = _Bare()
+    results = step_agents_multithreaded([noop, good])
+    assert len(results) == 1
+    assert results[0].success
+    assert good.counter == 1
+
+
+def test_sync_wrapper_unknown_mode_raises():
+    import mesa_llm.parallel_stepping as ps
+
+    original = ps._PARALLEL_STEPPING_MODE
+    try:
+        ps._PARALLEL_STEPPING_MODE = "unknown"
+        with pytest.raises(ValueError, match="Unknown parallel stepping mode"):
+            step_agents_parallel_sync([])
+    finally:
+        ps._PARALLEL_STEPPING_MODE = original

--- a/tests/test_parallel_error_handling.py
+++ b/tests/test_parallel_error_handling.py
@@ -252,6 +252,23 @@ def test_threaded_skips_agent_without_step_or_astep():
     assert good.counter == 1
 
 
+def test_sync_wrapper_threading_mode():
+    import mesa_llm.parallel_stepping as ps
+
+    original = ps._PARALLEL_STEPPING_MODE
+    try:
+        ps._PARALLEL_STEPPING_MODE = "threading"
+        m = DummyModel()
+        good = AsyncAgent(m)
+        bad = FailingAsyncAgent(m)
+        results = step_agents_parallel_sync([bad, good], on_error="continue")
+        assert good.counter == 1
+        failed = [r for r in results if not r.success]
+        assert len(failed) == 1
+    finally:
+        ps._PARALLEL_STEPPING_MODE = original
+
+
 def test_sync_wrapper_unknown_mode_raises():
     import mesa_llm.parallel_stepping as ps
 

--- a/tests/test_parallel_error_handling.py
+++ b/tests/test_parallel_error_handling.py
@@ -230,8 +230,6 @@ def test_backward_compat_no_params():
 class _Bare:
     """Object with neither step() nor astep() — should be skipped."""
 
-    pass
-
 
 @pytest.mark.asyncio
 async def test_parallel_skips_agent_without_step_or_astep():


### PR DESCRIPTION
## Summary

Closes #220

Fixes a critical bug where one agent's exception during parallel stepping crashes ALL other agent tasks. This is devastating for LLM-backed simulations where failures (rate limits, timeouts, JSON parse errors) are expected and common.

### `AgentStepResult` dataclass
- Structured result with `agent`, `success`, and `exception` fields
- Returned by all parallel stepping functions

### Error isolation in all 3 parallel paths
- `step_agents_parallel()` — `asyncio.gather(return_exceptions=True)` + per-result error logging
- `step_agents_multithreaded()` — try/except around `future.result()` + error logging
- `_agentset_do_async()` — same `return_exceptions=True` treatment

### Configurable error handling
- `on_error="continue"` (default) — log and continue, fully backward compatible
- `on_error="raise"` — propagate first exception for debugging
- Optional per-agent `timeout` — prevents one slow LLM call from blocking everything
- Config via function params or `enable_automatic_parallel_stepping(on_error=..., timeout=...)`

## Backward Compatibility

- Default `on_error="continue"` is strictly better than current behavior (crashes → logs & continues)
- All existing function signatures unchanged (new params are keyword-only with defaults)
- All 4 existing `test_parallel_stepping.py` tests pass unchanged
- Return type changes from `None` to `list[AgentStepResult]` — no existing code inspects the return

## Test Plan

- [x] All existing parallel stepping tests pass (4/4)
- [x] 13 new tests covering: error isolation (async + threaded), raise mode, timeout, do_async resilience, backward compat, config validation
- [x] Ruff lint and format checks pass