### PR TITLE
fix(memory): prevent add_to_memory() from overwriting events of the same type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -342,3 +342,12 @@ final_architecture.png
 GSoC_2025.md
 /architectures
 .instructions/
+
+# Diagnostic files
+output.txt
+pytest_failures.txt
+pytest_failures_all.txt
+show_stat.txt
+coverage.txt
+inbuilt_history.txt
+

--- a/mesa_llm/memory/episodic_memory.py
+++ b/mesa_llm/memory/episodic_memory.py
@@ -104,6 +104,7 @@ class EpisodicMemory(Memory):
         """
         Safely extracts importance score regardless of data structure.
         Handles:
+        - Nested in list: {"msg": [{"importance": 5}]}
         - Nested: {"msg": {"importance": 5}}
         - Flat:   {"importance": 5}
         """
@@ -112,7 +113,13 @@ class EpisodicMemory(Memory):
             return val if isinstance(val, (int, float)) else 1
 
         for value in entry.content.values():
-            if isinstance(value, dict) and "importance" in value:
+            if isinstance(value, list) and value:
+                # Handle unified structure where each type maps to a list
+                item = value[0]
+                if isinstance(item, dict) and "importance" in item:
+                    val = item["importance"]
+                    return val if isinstance(val, (int, float)) else 1
+            elif isinstance(value, dict) and "importance" in value:
                 val = value["importance"]
                 return val if isinstance(val, (int, float)) else 1
 
@@ -210,7 +217,7 @@ class EpisodicMemory(Memory):
         """Create and persist a finalized episodic entry."""
         new_entry = MemoryEntry(
             agent=self.agent,
-            content={type: graded_content},
+            content={type: [graded_content]},
             step=self.agent.model.steps,
         )
         self.memory_entries.append(new_entry)
@@ -247,13 +254,18 @@ class EpisodicMemory(Memory):
         """
         Get the communication history
         """
-        return "\n".join(
-            [
-                f"step {entry.step}: {entry.content['message']}\n\n"
-                for entry in self.memory_entries
-                if "message" in entry.content
-            ]
-        )
+        history = []
+        for entry in self.memory_entries:
+            if "message" in entry.content:
+                messages = entry.content["message"]
+                # Unified structure means message is a list
+                if isinstance(messages, list):
+                    for msg_entry in messages:
+                        msg = msg_entry.get("message", msg_entry)
+                        history.append(f"step {entry.step}: {msg}")
+                else:
+                    history.append(f"step {entry.step}: {messages}")
+        return "\n\n".join(history)
 
     async def aprocess_step(self, pre_step: bool = False):
         """

--- a/mesa_llm/memory/lt_memory.py
+++ b/mesa_llm/memory/lt_memory.py
@@ -93,7 +93,13 @@ class LongTermMemory(Memory):
             return
 
         elif self.buffer and self.buffer.step is None:
-            self.step_content.update(self.buffer.content)
+            # Merge current and pre-step content. Both are dicts of lists.
+            for k, v in self.buffer.content.items():
+                if k in self.step_content and isinstance(self.step_content[k], list) and isinstance(v, list):
+                    self.step_content[k] = v + self.step_content[k] # Pre-step goes first
+                else:
+                    self.step_content[k] = v
+                    
             new_entry = MemoryEntry(
                 agent=self.agent,
                 content=self.step_content,
@@ -124,7 +130,13 @@ class LongTermMemory(Memory):
             return
 
         elif self.buffer and self.buffer.step is None:
-            self.step_content.update(self.buffer.content)
+            # Merge current and pre-step content. Both are dicts of lists.
+            for k, v in self.buffer.content.items():
+                if k in self.step_content and isinstance(self.step_content[k], list) and isinstance(v, list):
+                    self.step_content[k] = v + self.step_content[k] # Pre-step goes first
+                else:
+                    self.step_content[k] = v
+                    
             new_entry = MemoryEntry(
                 agent=self.agent,
                 content=self.step_content,

--- a/mesa_llm/memory/lt_memory.py
+++ b/mesa_llm/memory/lt_memory.py
@@ -95,11 +95,17 @@ class LongTermMemory(Memory):
         elif self.buffer and self.buffer.step is None:
             # Merge current and pre-step content. Both are dicts of lists.
             for k, v in self.buffer.content.items():
-                if k in self.step_content and isinstance(self.step_content[k], list) and isinstance(v, list):
-                    self.step_content[k] = v + self.step_content[k] # Pre-step goes first
+                if (
+                    k in self.step_content
+                    and isinstance(self.step_content[k], list)
+                    and isinstance(v, list)
+                ):
+                    self.step_content[k] = (
+                        v + self.step_content[k]
+                    )  # Pre-step goes first
                 else:
                     self.step_content[k] = v
-                    
+
             new_entry = MemoryEntry(
                 agent=self.agent,
                 content=self.step_content,
@@ -132,11 +138,17 @@ class LongTermMemory(Memory):
         elif self.buffer and self.buffer.step is None:
             # Merge current and pre-step content. Both are dicts of lists.
             for k, v in self.buffer.content.items():
-                if k in self.step_content and isinstance(self.step_content[k], list) and isinstance(v, list):
-                    self.step_content[k] = v + self.step_content[k] # Pre-step goes first
+                if (
+                    k in self.step_content
+                    and isinstance(self.step_content[k], list)
+                    and isinstance(v, list)
+                ):
+                    self.step_content[k] = (
+                        v + self.step_content[k]
+                    )  # Pre-step goes first
                 else:
                     self.step_content[k] = v
-                    
+
             new_entry = MemoryEntry(
                 agent=self.agent,
                 content=self.step_content,

--- a/mesa_llm/memory/memory.py
+++ b/mesa_llm/memory/memory.py
@@ -169,10 +169,10 @@ class Memory(ABC):
                 k: v for k, v in content.items() if v != self.last_observation.get(k)
             }
             if changed_parts:
-                self.step_content[type] = changed_parts
+                self.step_content.setdefault(type, []).append(changed_parts)
             self.last_observation = content
         else:
-            self.step_content[type] = content
+            self.step_content.setdefault(type, []).append(content)
 
     # Async Function wrapper for add_to_memory()
     async def aadd_to_memory(self, type: str, content: dict):

--- a/mesa_llm/memory/st_lt_memory.py
+++ b/mesa_llm/memory/st_lt_memory.py
@@ -120,11 +120,15 @@ class STLTMemory(Memory):
         if not self.short_term_memory or self.short_term_memory[-1].step is not None:
             return None, False
         pre_step_entry = self.short_term_memory.pop()
-        
+
         # Merge current and pre-step content. Both are dicts of lists.
         for k, v in pre_step_entry.content.items():
-            if k in self.step_content and isinstance(self.step_content[k], list) and isinstance(v, list):
-                self.step_content[k] = v + self.step_content[k] # Pre-step goes first
+            if (
+                k in self.step_content
+                and isinstance(self.step_content[k], list)
+                and isinstance(v, list)
+            ):
+                self.step_content[k] = v + self.step_content[k]  # Pre-step goes first
             else:
                 self.step_content[k] = v
 

--- a/mesa_llm/memory/st_lt_memory.py
+++ b/mesa_llm/memory/st_lt_memory.py
@@ -120,7 +120,14 @@ class STLTMemory(Memory):
         if not self.short_term_memory or self.short_term_memory[-1].step is not None:
             return None, False
         pre_step_entry = self.short_term_memory.pop()
-        self.step_content.update(pre_step_entry.content)
+        
+        # Merge current and pre-step content. Both are dicts of lists.
+        for k, v in pre_step_entry.content.items():
+            if k in self.step_content and isinstance(self.step_content[k], list) and isinstance(v, list):
+                self.step_content[k] = v + self.step_content[k] # Pre-step goes first
+            else:
+                self.step_content[k] = v
+
         new_entry = MemoryEntry(
             agent=self.agent,
             content=self.step_content,
@@ -202,10 +209,15 @@ class STLTMemory(Memory):
         """
         Get the communication history
         """
-        return "\n".join(
-            [
-                f"step {entry.step}: {entry.content['message']}\n\n"
-                for entry in self.short_term_memory
-                if "message" in entry.content
-            ]
-        )
+        history = []
+        for entry in self.short_term_memory:
+            if "message" in entry.content:
+                messages = entry.content["message"]
+                # Unified structure means message is a list
+                if isinstance(messages, list):
+                    for msg_entry in messages:
+                        msg = msg_entry.get("message", msg_entry)
+                        history.append(f"step {entry.step}: {msg}")
+                else:
+                    history.append(f"step {entry.step}: {messages}")
+        return "\n\n".join(history)

--- a/mesa_llm/memory/st_memory.py
+++ b/mesa_llm/memory/st_memory.py
@@ -61,8 +61,14 @@ class ShortTermMemory(Memory):
 
         new_entry = None
         if self._current_step_entry is not None:
+            # Merge current and pre-step content. Both are dicts of lists.
             merged_content = dict(self.step_content)
-            merged_content.update(self._current_step_entry.content)
+            for k, v in self._current_step_entry.content.items():
+                if k in merged_content and isinstance(merged_content[k], list) and isinstance(v, list):
+                    merged_content[k] = v + merged_content[k] # Pre-step goes first
+                else:
+                    merged_content[k] = v
+
             new_entry = MemoryEntry(
                 agent=self.agent,
                 content=merged_content,
@@ -98,10 +104,15 @@ class ShortTermMemory(Memory):
         """
         Get the communication history
         """
-        return "\n".join(
-            [
-                f"step {entry.step}: {entry.content['message']}\n\n"
-                for entry in self.short_term_memory
-                if "message" in entry.content
-            ]
-        )
+        history = []
+        for entry in self.short_term_memory:
+            if "message" in entry.content:
+                messages = entry.content["message"]
+                # Unified structure means message is a list
+                if isinstance(messages, list):
+                    for msg_entry in messages:
+                        msg = msg_entry.get("message", msg_entry)
+                        history.append(f"step {entry.step}: {msg}")
+                else:
+                    history.append(f"step {entry.step}: {messages}")
+        return "\n\n".join(history)

--- a/mesa_llm/memory/st_memory.py
+++ b/mesa_llm/memory/st_memory.py
@@ -64,8 +64,12 @@ class ShortTermMemory(Memory):
             # Merge current and pre-step content. Both are dicts of lists.
             merged_content = dict(self.step_content)
             for k, v in self._current_step_entry.content.items():
-                if k in merged_content and isinstance(merged_content[k], list) and isinstance(v, list):
-                    merged_content[k] = v + merged_content[k] # Pre-step goes first
+                if (
+                    k in merged_content
+                    and isinstance(merged_content[k], list)
+                    and isinstance(v, list)
+                ):
+                    merged_content[k] = v + merged_content[k]  # Pre-step goes first
                 else:
                     merged_content[k] = v
 

--- a/tests/test_integration/test_memory_reasoning.py
+++ b/tests/test_integration/test_memory_reasoning.py
@@ -127,9 +127,9 @@ class TestCoTWithShortTermMemory:
         assert isinstance(plan, Plan)
         assert plan.step == 1
         assert plan.llm_plan is rsp_exec.choices[0].message
-        assert memory.step_content["Observation"]["content"] == str(obs)
-        assert memory.step_content["Plan"]["content"] == plan_content
-        assert memory.step_content["Plan-Execution"]["content"] == str(plan)
+        assert memory.step_content["Observation"][0]["content"] == str(obs)
+        assert memory.step_content["Plan"][0]["content"] == plan_content
+        assert memory.step_content["Plan-Execution"][0]["content"] == str(plan)
         assert agent._step_display_data["plan_content"] == plan_content
         assert agent.llm.generate.call_count == 2
 
@@ -149,9 +149,9 @@ class TestCoTWithShortTermMemory:
         assert isinstance(plan, Plan)
         assert plan.step == 1
         assert plan.llm_plan is rsp_exec.choices[0].message
-        assert memory.step_content["Observation"]["content"] == str(obs)
-        assert memory.step_content["Plan"]["content"] == plan_content
-        assert memory.step_content["Plan-Execution"]["content"] == str(plan)
+        assert memory.step_content["Observation"][0]["content"] == str(obs)
+        assert memory.step_content["Plan"][0]["content"] == plan_content
+        assert memory.step_content["Plan-Execution"][0]["content"] == str(plan)
         assert agent._step_display_data["plan_content"] == plan_content
         assert agent.llm.agenerate.await_count == 2
 
@@ -205,9 +205,9 @@ class TestCoTWithSTLTMemory:
 
         assert isinstance(plan, Plan)
         assert plan.step == 1
-        assert memory.step_content["Observation"]["content"] == str(obs)
-        assert memory.step_content["Plan"]["content"] == plan_content
-        assert memory.step_content["Plan-Execution"]["content"] == str(plan)
+        assert memory.step_content["Observation"][0]["content"] == str(obs)
+        assert memory.step_content["Plan"][0]["content"] == plan_content
+        assert memory.step_content["Plan-Execution"][0]["content"] == str(plan)
         assert agent.llm.generate.call_count == 2
 
     def test_async_plan_works(self, monkeypatch):
@@ -225,9 +225,9 @@ class TestCoTWithSTLTMemory:
 
         assert isinstance(plan, Plan)
         assert plan.step == 1
-        assert memory.step_content["Observation"]["content"] == str(obs)
-        assert memory.step_content["Plan"]["content"] == plan_content
-        assert memory.step_content["Plan-Execution"]["content"] == str(plan)
+        assert memory.step_content["Observation"][0]["content"] == str(obs)
+        assert memory.step_content["Plan"][0]["content"] == plan_content
+        assert memory.step_content["Plan-Execution"][0]["content"] == str(plan)
         assert agent.llm.agenerate.await_count == 2
 
 
@@ -282,12 +282,12 @@ class TestCoTWithEpisodicMemory:
         assert isinstance(plan, Plan)
         entries = list(memory.memory_entries)
         assert len(entries) == 3
-        assert entries[0].content["Observation"]["content"] == str(obs)
-        assert entries[1].content["Plan"]["content"] == plan_content
-        assert entries[2].content["Plan-Execution"]["content"] == str(plan)
-        assert entries[0].content["Observation"]["importance"] == 3
-        assert entries[1].content["Plan"]["importance"] == 3
-        assert entries[2].content["Plan-Execution"]["importance"] == 3
+        assert entries[0].content["Observation"][0]["content"] == str(obs)
+        assert entries[1].content["Plan"][0]["content"] == plan_content
+        assert entries[2].content["Plan-Execution"][0]["content"] == str(plan)
+        assert entries[0].content["Observation"][0]["importance"] == 3
+        assert entries[1].content["Plan"][0]["importance"] == 3
+        assert entries[2].content["Plan-Execution"][0]["importance"] == 3
         assert memory.grade_event_importance.call_count == 3
 
     def test_async_plan_works(self, monkeypatch):
@@ -305,12 +305,12 @@ class TestCoTWithEpisodicMemory:
         assert isinstance(plan, Plan)
         entries = list(memory.memory_entries)
         assert len(entries) == 3
-        assert entries[0].content["Observation"]["content"] == str(obs)
-        assert entries[1].content["Plan"]["content"] == plan_content
-        assert entries[2].content["Plan-Execution"]["content"] == str(plan)
-        assert entries[0].content["Observation"]["importance"] == 3
-        assert entries[1].content["Plan"]["importance"] == 3
-        assert entries[2].content["Plan-Execution"]["importance"] == 3
+        assert entries[0].content["Observation"][0]["content"] == str(obs)
+        assert entries[1].content["Plan"][0]["content"] == plan_content
+        assert entries[2].content["Plan-Execution"][0]["content"] == str(plan)
+        assert entries[0].content["Observation"][0]["importance"] == 3
+        assert entries[1].content["Plan"][0]["importance"] == 3
+        assert entries[2].content["Plan-Execution"][0]["importance"] == 3
         assert memory.agrade_event_importance.await_count == 3
 
 
@@ -380,8 +380,8 @@ class TestReActWithSTLTMemory:
         plan = reasoning.plan(obs=obs)
 
         assert isinstance(plan, Plan)
-        assert memory.step_content["plan"]["reasoning"] == "test reasoning"
-        assert memory.step_content["plan"]["action"] == "test action"
+        assert memory.step_content["plan"][0]["reasoning"] == "test reasoning"
+        assert memory.step_content["plan"][0]["action"] == "test action"
         assert reasoning.execute_tool_call.call_args.args[0] == "test action"
         assert agent.llm.generate.call_count == 1
 
@@ -402,8 +402,8 @@ class TestReActWithSTLTMemory:
         plan = asyncio.run(reasoning.aplan(obs=obs))
 
         assert isinstance(plan, Plan)
-        assert memory.step_content["plan"]["reasoning"] == "test reasoning"
-        assert memory.step_content["plan"]["action"] == "test action"
+        assert memory.step_content["plan"][0]["reasoning"] == "test reasoning"
+        assert memory.step_content["plan"][0]["action"] == "test action"
         assert reasoning.aexecute_tool_call.await_args.args[0] == "test action"
         assert agent.llm.agenerate.await_count == 1
 
@@ -518,7 +518,7 @@ class TestReWOOWithShortTermMemory:
 
         plan = reasoning.plan()
         assert isinstance(plan, Plan)
-        assert memory.step_content["plan"]["content"] == plan_content
+        assert memory.step_content["plan"][0]["content"] == plan_content
         reasoning.execute_tool_call.assert_called_once_with(
             plan_content, selected_tools=None, ttl=1
         )
@@ -600,7 +600,7 @@ class TestReWOOWithSTLTMemory:
 
         plan = reasoning.plan()
         assert isinstance(plan, Plan)
-        assert memory.step_content["plan"]["content"] == plan_content
+        assert memory.step_content["plan"][0]["content"] == plan_content
         reasoning.execute_tool_call.assert_called_once_with(
             plan_content, selected_tools=None, ttl=1
         )
@@ -621,7 +621,7 @@ class TestReWOOWithSTLTMemory:
 
         plan = asyncio.run(reasoning.aplan())
         assert isinstance(plan, Plan)
-        assert memory.step_content["plan"]["content"] == plan_content
+        assert memory.step_content["plan"][0]["content"] == plan_content
         reasoning.aexecute_tool_call.assert_awaited_once_with(
             plan_content, selected_tools=None, ttl=1
         )
@@ -683,8 +683,8 @@ class TestReWOOWithEpisodicMemory:
         assert isinstance(plan, Plan)
         entries = list(memory.memory_entries)
         assert len(entries) == 1
-        assert entries[0].content["plan"]["content"] == plan_content
-        assert entries[0].content["plan"]["importance"] == 3
+        assert entries[0].content["plan"][0]["content"] == plan_content
+        assert entries[0].content["plan"][0]["importance"] == 3
         assert memory.grade_event_importance.call_count == 1
         reasoning.execute_tool_call.assert_called_once_with(
             plan_content, selected_tools=None, ttl=1
@@ -707,8 +707,8 @@ class TestReWOOWithEpisodicMemory:
         assert isinstance(plan, Plan)
         entries = list(memory.memory_entries)
         assert len(entries) == 1
-        assert entries[0].content["plan"]["content"] == plan_content
-        assert entries[0].content["plan"]["importance"] == 3
+        assert entries[0].content["plan"][0]["content"] == plan_content
+        assert entries[0].content["plan"][0]["importance"] == 3
         assert memory.grade_event_importance.call_count == 1
         reasoning.aexecute_tool_call.assert_awaited_once_with(
             plan_content, selected_tools=None, ttl=1

--- a/tests/test_llm_agent.py
+++ b/tests/test_llm_agent.py
@@ -62,9 +62,9 @@ def test_apply_plan_adds_to_memory(monkeypatch):
 
     action_content = agent.memory.step_content.get("action")
     assert action_content is not None
-    assert "tool_calls" in action_content
-    assert len(action_content["tool_calls"]) == 1
-    assert action_content["tool_calls"][0] == {"tool": "foo", "argument": "bar"}
+    assert "tool_calls" in action_content[0]
+    assert len(action_content[0]["tool_calls"]) == 1
+    assert action_content[0]["tool_calls"][0] == {"tool": "foo", "argument": "bar"}
 
 
 def test_apply_plan_preserves_multiple_tool_calls(monkeypatch):
@@ -111,13 +111,13 @@ def test_apply_plan_preserves_multiple_tool_calls(monkeypatch):
 
     action_content = agent.memory.step_content.get("action")
     assert action_content is not None
-    assert "tool_calls" in action_content
-    assert len(action_content["tool_calls"]) == 2
-    assert action_content["tool_calls"][0] == {
+    assert "tool_calls" in action_content[0]
+    assert len(action_content[0]["tool_calls"]) == 2
+    assert action_content[0]["tool_calls"][0] == {
         "name": "move_one_step",
         "response": "agent moved to (3, 4)",
     }
-    assert action_content["tool_calls"][1] == {
+    assert action_content[0]["tool_calls"][1] == {
         "name": "arrest_citizen",
         "response": "Citizen 12 arrested",
     }
@@ -170,13 +170,13 @@ async def test_aapply_plan_preserves_multiple_tool_calls(monkeypatch):
 
     action_content = agent.memory.step_content.get("action")
     assert action_content is not None
-    assert "tool_calls" in action_content
-    assert len(action_content["tool_calls"]) == 2
-    assert action_content["tool_calls"][0] == {
+    assert "tool_calls" in action_content[0]
+    assert len(action_content[0]["tool_calls"]) == 2
+    assert action_content[0]["tool_calls"][0] == {
         "name": "move_one_step",
         "response": "agent moved to (3, 4)",
     }
-    assert action_content["tool_calls"][1] == {
+    assert action_content[0]["tool_calls"][1] == {
         "name": "arrest_citizen",
         "response": "Citizen 12 arrested",
     }

--- a/tests/test_memory/test_episodic_memory.py
+++ b/tests/test_memory/test_episodic_memory.py
@@ -80,6 +80,7 @@ class TestEpisodicMemory:
         assert len(memory.memory_entries) == 3, (
             "add_to_memory graded the event but never created a MemoryEntry"
         )
+        assert isinstance(memory.memory_entries[0].content["observation"], list)
 
     def test_finalize_entry_consistency(self, mock_agent):
         """Minimal tests for the helper function _finalize_entry().
@@ -93,7 +94,7 @@ class TestEpisodicMemory:
 
         memory._finalize_entry("observation", graded_content)
 
-        assert memory.memory_entries[0].content["observation"]["importance"] == 4
+        assert memory.memory_entries[0].content["observation"][0]["importance"] == 4
         assert memory.step_content == {}
         assert isinstance(memory.memory_entries[0], MemoryEntry)
         assert memory.memory_entries[0].step == mock_agent.model.steps
@@ -267,7 +268,7 @@ class TestEpisodicMemory:
 
         for new_entry in memory.memory_entries:
             event_type = next(iter(new_entry.content.keys()))
-            assert new_entry.content[event_type]["importance"] == 3
+            assert new_entry.content[event_type][0]["importance"] == 3
         assert memory.step_content == {}
         assert len(memory.memory_entries) == 3, (
             "aadd_to_memory graded the event but never created a MemoryEntry"
@@ -347,7 +348,7 @@ class TestEpisodicMemory:
         """Function to return importance when stored at top level"""
         memory = EpisodicMemory(agent=mock_agent, llm_model="provider/test_model")
         entry = MemoryEntry(
-            content={"importance": 5, "message": "hello"},
+            content={"message": [{"importance": 5, "message": "hello"}]},
             step=1,
             agent=mock_agent,
         )
@@ -359,7 +360,7 @@ class TestEpisodicMemory:
         memory = EpisodicMemory(agent=mock_agent, llm_model="provider/test_model")
 
         entry = MemoryEntry(
-            content={"message": {"importance": 4, "text": "nested"}},
+            content={"message": [{"importance": 4, "text": "nested"}]},
             step=1,
             agent=mock_agent,
         )

--- a/tests/test_memory/test_memory_parent.py
+++ b/tests/test_memory/test_memory_parent.py
@@ -127,6 +127,9 @@ class TestMemoryParent:
         # Should be non-empty step_content after adding to memory
         assert memory.step_content != {}
         assert "observation" in memory.step_content
+        assert isinstance(memory.step_content["observation"], list)
+        assert isinstance(memory.step_content["planning"], list)
+        assert isinstance(memory.step_content["action"], list)
 
     def test_add_to_memory_rejects_non_dict_content(self, mock_agent):
         memory = MemoryMock(agent=mock_agent)
@@ -149,3 +152,19 @@ class TestMemoryParent:
             str(exc_info.value)
             == "Expected 'content' to be dict, got str: 'raw async string plan'"
         )
+
+    def test_add_to_memory_preserves_multiple_entries(self):
+        """Multiple add_to_memory calls with the same type should accumulate, not overwrite."""
+        mock_agent = Mock()
+        memory = MemoryMock(agent=mock_agent)
+
+        memory.add_to_memory("message", {"text": "Hello"})
+        memory.add_to_memory("message", {"text": "World"})
+
+        assert "message" in memory.step_content
+        assert isinstance(memory.step_content["message"], list), (
+            "Expected message entries to be accumulated in a list"
+        )
+        assert len(memory.step_content["message"]) == 2
+        assert memory.step_content["message"][0] == {"text": "Hello"}
+        assert memory.step_content["message"][1] == {"text": "World"}


### PR DESCRIPTION
~~Fixes #242~~
Fixes #137
