### PR TITLE
fix: relative imports for examples in mesa-llm

### DIFF
--- a/examples/epstein_civil_violence/app.py
+++ b/examples/epstein_civil_violence/app.py
@@ -9,8 +9,8 @@ from mesa.visualization import (
     make_space_component,
 )
 
-from examples.epstein_civil_violence.agents import Citizen, CitizenState, Cop
-from examples.epstein_civil_violence.model import EpsteinModel
+from .agents import Citizen, CitizenState, Cop
+from .model import EpsteinModel
 from mesa_llm.parallel_stepping import enable_automatic_parallel_stepping
 from mesa_llm.reasoning.react import ReActReasoning
 

--- a/examples/epstein_civil_violence/app.py
+++ b/examples/epstein_civil_violence/app.py
@@ -9,10 +9,11 @@ from mesa.visualization import (
     make_space_component,
 )
 
-from .agents import Citizen, CitizenState, Cop
-from .model import EpsteinModel
 from mesa_llm.parallel_stepping import enable_automatic_parallel_stepping
 from mesa_llm.reasoning.react import ReActReasoning
+
+from .agents import Citizen, CitizenState, Cop
+from .model import EpsteinModel
 
 # Suppress Pydantic serialization warnings
 warnings.filterwarnings(

--- a/examples/epstein_civil_violence/model.py
+++ b/examples/epstein_civil_violence/model.py
@@ -3,9 +3,10 @@ from mesa.model import Model
 from mesa.space import MultiGrid
 from rich import print
 
-from .agents import Citizen, CitizenState, Cop
 from mesa_llm.reasoning.reasoning import Reasoning
 from mesa_llm.recording.record_model import record_model
+
+from .agents import Citizen, CitizenState, Cop
 
 
 @record_model(output_dir="recordings")

--- a/examples/epstein_civil_violence/model.py
+++ b/examples/epstein_civil_violence/model.py
@@ -3,7 +3,7 @@ from mesa.model import Model
 from mesa.space import MultiGrid
 from rich import print
 
-from examples.epstein_civil_violence.agents import Citizen, CitizenState, Cop
+from .agents import Citizen, CitizenState, Cop
 from mesa_llm.reasoning.reasoning import Reasoning
 from mesa_llm.recording.record_model import record_model
 
@@ -111,7 +111,7 @@ if __name__ == "__main__":
     run the model without the solara integration with:
     conda activate mesa-llm && python -m examples.epstein_civil_violence.model
     """
-    from examples.epstein_civil_violence.app import model
+    from .app import model
 
     for _ in range(5):
         model.step()

--- a/examples/epstein_civil_violence/tools.py
+++ b/examples/epstein_civil_violence/tools.py
@@ -1,7 +1,7 @@
 import random
 from typing import TYPE_CHECKING
 
-from examples.epstein_civil_violence.agents import (
+from .agents import (
     CitizenState,
     citizen_tool_manager,
     cop_tool_manager,

--- a/examples/epstein_civil_violence/tools.py
+++ b/examples/epstein_civil_violence/tools.py
@@ -1,12 +1,13 @@
 import random
 from typing import TYPE_CHECKING
 
+from mesa_llm.tools.tool_decorator import tool
+
 from .agents import (
     CitizenState,
     citizen_tool_manager,
     cop_tool_manager,
 )
-from mesa_llm.tools.tool_decorator import tool
 
 if TYPE_CHECKING:
     from mesa_llm.llm_agent import LLMAgent

--- a/examples/negotiation/app.py
+++ b/examples/negotiation/app.py
@@ -10,10 +10,11 @@ from mesa.visualization import (
     make_space_component,
 )
 
-from .agents import BuyerAgent, SellerAgent
-from .model import NegotiationModel
 from mesa_llm.parallel_stepping import enable_automatic_parallel_stepping
 from mesa_llm.reasoning.react import ReActReasoning
+
+from .agents import BuyerAgent, SellerAgent
+from .model import NegotiationModel
 
 # Suppress Pydantic serialization warnings
 warnings.filterwarnings(

--- a/examples/negotiation/app.py
+++ b/examples/negotiation/app.py
@@ -10,8 +10,8 @@ from mesa.visualization import (
     make_space_component,
 )
 
-from examples.negotiation.agents import BuyerAgent, SellerAgent
-from examples.negotiation.model import NegotiationModel
+from .agents import BuyerAgent, SellerAgent
+from .model import NegotiationModel
 from mesa_llm.parallel_stepping import enable_automatic_parallel_stepping
 from mesa_llm.reasoning.react import ReActReasoning
 

--- a/examples/negotiation/model.py
+++ b/examples/negotiation/model.py
@@ -5,7 +5,7 @@ from mesa.model import Model
 from mesa.space import MultiGrid
 from rich import print
 
-from examples.negotiation.agents import BuyerAgent, SellerAgent
+from .agents import BuyerAgent, SellerAgent
 from mesa_llm.reasoning.reasoning import Reasoning
 
 
@@ -133,7 +133,7 @@ if __name__ == "__main__":
     conda activate mesa-llm && python -m examples.negotiation.model
     """
 
-    from examples.negotiation.app import model
+    from .app import model
 
     # Run the model for 10 steps
     for _ in range(10):

--- a/examples/negotiation/model.py
+++ b/examples/negotiation/model.py
@@ -5,8 +5,9 @@ from mesa.model import Model
 from mesa.space import MultiGrid
 from rich import print
 
-from .agents import BuyerAgent, SellerAgent
 from mesa_llm.reasoning.reasoning import Reasoning
+
+from .agents import BuyerAgent, SellerAgent
 
 
 # @record_model

--- a/examples/negotiation/tools.py
+++ b/examples/negotiation/tools.py
@@ -1,7 +1,8 @@
 from typing import TYPE_CHECKING
 
-from .agents import buyer_tool_manager
 from mesa_llm.tools.tool_decorator import tool
+
+from .agents import buyer_tool_manager
 
 if TYPE_CHECKING:
     from mesa_llm.llm_agent import LLMAgent

--- a/examples/negotiation/tools.py
+++ b/examples/negotiation/tools.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from examples.negotiation.agents import buyer_tool_manager
+from .agents import buyer_tool_manager
 from mesa_llm.tools.tool_decorator import tool
 
 if TYPE_CHECKING:

--- a/examples/sugarscrap_g1mt/app.py
+++ b/examples/sugarscrap_g1mt/app.py
@@ -9,9 +9,10 @@ from mesa.visualization import (
     make_space_component,
 )
 
+from mesa_llm.reasoning.react import ReActReasoning
+
 from .agents import Resource, Trader
 from .model import SugarScapeModel
-from mesa_llm.reasoning.react import ReActReasoning
 
 # Suppress Pydantic serialization warnings
 warnings.filterwarnings(

--- a/examples/sugarscrap_g1mt/app.py
+++ b/examples/sugarscrap_g1mt/app.py
@@ -9,8 +9,8 @@ from mesa.visualization import (
     make_space_component,
 )
 
-from examples.sugarscrap_g1mt.agents import Resource, Trader
-from examples.sugarscrap_g1mt.model import SugarScapeModel
+from .agents import Resource, Trader
+from .model import SugarScapeModel
 from mesa_llm.reasoning.react import ReActReasoning
 
 # Suppress Pydantic serialization warnings

--- a/examples/sugarscrap_g1mt/model.py
+++ b/examples/sugarscrap_g1mt/model.py
@@ -6,7 +6,7 @@ from mesa.model import Model
 from mesa.space import MultiGrid
 from rich import print
 
-from examples.sugarscrap_g1mt.agents import Resource, Trader
+from .agents import Resource, Trader
 from mesa_llm.reasoning.reasoning import Reasoning
 from mesa_llm.recording.record_model import record_model
 

--- a/examples/sugarscrap_g1mt/model.py
+++ b/examples/sugarscrap_g1mt/model.py
@@ -6,9 +6,10 @@ from mesa.model import Model
 from mesa.space import MultiGrid
 from rich import print
 
-from .agents import Resource, Trader
 from mesa_llm.reasoning.reasoning import Reasoning
 from mesa_llm.recording.record_model import record_model
+
+from .agents import Resource, Trader
 
 
 # Helper Functions

--- a/examples/sugarscrap_g1mt/tools.py
+++ b/examples/sugarscrap_g1mt/tools.py
@@ -1,11 +1,12 @@
 from typing import TYPE_CHECKING
 
+from mesa_llm.tools.tool_decorator import tool
+
 from .agents import (
     Resource,
     Trader,
     trader_tool_manager,
 )
-from mesa_llm.tools.tool_decorator import tool
 
 if TYPE_CHECKING:
     from mesa_llm.llm_agent import LLMAgent

--- a/examples/sugarscrap_g1mt/tools.py
+++ b/examples/sugarscrap_g1mt/tools.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from examples.sugarscrap_g1mt.agents import (
+from .agents import (
     Resource,
     Trader,
     trader_tool_manager,


### PR DESCRIPTION
Updated the three examples (negotiation, epstein_civil_violence, and sugarscrap_g1mt) to use relative imports instead of absolute imports because of ModuleNotFoundError when running solara from the example directory as described in the README

Maybe it's better to change the README ? 

Tested locally by running solara run app.py from the example directory