### PR TITLE
fix: add include_default_tools parameter to LLMAgent to prevent unwanted inbuilt tool calls

### DIFF
--- a/mesa_llm/llm_agent.py
+++ b/mesa_llm/llm_agent.py
@@ -17,6 +17,7 @@ from mesa_llm.reasoning.reasoning import (
     Observation,
     Reasoning,
 )
+from mesa_llm.tools.inbuilt_tools import INBUILT_TOOL_NAMES
 from mesa_llm.tools.tool_manager import ToolManager
 
 
@@ -38,6 +39,10 @@ class LLMAgent(Agent):
             the agent each step.
         api_base (str | None): Optional custom LiteLLM-compatible base URL for
             self-hosted or remote inference endpoints.
+        include_default_tools (bool): Whether to include the built-in tools
+            (``move_one_step``, ``teleport_to_location``, ``speak_to``) in
+            this agent's tool manager. Set to ``False`` when the agent should
+            only have access to domain-specific tools. Defaults to ``True``.
 
     Attributes:
         llm (ModuleLLM): The internal LLM interface used by the agent.
@@ -55,6 +60,7 @@ class LLMAgent(Agent):
         internal_state: list[str] | str | None = None,
         step_prompt: str | None = None,
         api_base: str | None = None,
+        include_default_tools: bool = True,
     ):
         super().__init__(model=model)
 
@@ -73,6 +79,9 @@ class LLMAgent(Agent):
         )
 
         self.tool_manager = ToolManager()
+        if not include_default_tools:
+            for name in INBUILT_TOOL_NAMES:
+                self.tool_manager.tools.pop(name, None)
         self.vision = vision
         self.reasoning = reasoning(agent=self)
         self.system_prompt = system_prompt

--- a/mesa_llm/tools/inbuilt_tools.py
+++ b/mesa_llm/tools/inbuilt_tools.py
@@ -18,6 +18,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+INBUILT_TOOL_NAMES: frozenset[str] = frozenset(
+    {"move_one_step", "teleport_to_location", "speak_to"}
+)
+
 # Mapping directions to (dx, dy) for Cartesian-style spaces.
 direction_map_xy = {
     "North": (0, 1),

--- a/tests/test_llm_agent.py
+++ b/tests/test_llm_agent.py
@@ -974,9 +974,7 @@ def test_include_default_tools_false_removes_inbuilt(monkeypatch):
     """When include_default_tools=False, inbuilt tools are removed."""
     monkeypatch.setenv("GEMINI_API_KEY", "dummy")
     model = Model(rng=42)
-    agent = LLMAgent(
-        model=model, reasoning=ReActReasoning, include_default_tools=False
-    )
+    agent = LLMAgent(model=model, reasoning=ReActReasoning, include_default_tools=False)
 
     for name in INBUILT_TOOL_NAMES:
         assert not agent.tool_manager.has_tool(name), f"{name} should NOT be registered"

--- a/tests/test_llm_agent.py
+++ b/tests/test_llm_agent.py
@@ -13,6 +13,7 @@ from mesa_llm import Plan
 from mesa_llm.llm_agent import LLMAgent
 from mesa_llm.memory.st_memory import ShortTermMemory
 from mesa_llm.reasoning.react import ReActReasoning
+from mesa_llm.tools.inbuilt_tools import INBUILT_TOOL_NAMES
 
 
 def test_apply_plan_adds_to_memory(monkeypatch):
@@ -957,3 +958,55 @@ async def test_asend_message_stores_serializable_ids(monkeypatch):
     assert data["sender"] == 10
     assert data["message"] == "hello"
     assert "recipients" not in data
+
+
+def test_include_default_tools_true_by_default(monkeypatch):
+    """Default behavior: inbuilt tools are present in the tool manager."""
+    monkeypatch.setenv("GEMINI_API_KEY", "dummy")
+    model = Model(rng=42)
+    agent = LLMAgent(model=model, reasoning=ReActReasoning)
+
+    for name in INBUILT_TOOL_NAMES:
+        assert agent.tool_manager.has_tool(name), f"{name} should be registered"
+
+
+def test_include_default_tools_false_removes_inbuilt(monkeypatch):
+    """When include_default_tools=False, inbuilt tools are removed."""
+    monkeypatch.setenv("GEMINI_API_KEY", "dummy")
+    model = Model(rng=42)
+    agent = LLMAgent(
+        model=model, reasoning=ReActReasoning, include_default_tools=False
+    )
+
+    for name in INBUILT_TOOL_NAMES:
+        assert not agent.tool_manager.has_tool(name), f"{name} should NOT be registered"
+
+
+def test_include_default_tools_false_keeps_user_tools(monkeypatch):
+    """User-defined global tools survive when include_default_tools=False."""
+    monkeypatch.setenv("GEMINI_API_KEY", "dummy")
+    from mesa_llm.tools.tool_decorator import _GLOBAL_TOOL_REGISTRY, tool
+
+    @tool
+    def custom_domain_tool(agent, value: int) -> str:
+        """A user-defined domain tool.
+
+        Args:
+            value: The input value.
+
+        Returns:
+            Confirmation string.
+        """
+        return f"done {value}"
+
+    try:
+        model = Model(rng=42)
+        agent = LLMAgent(
+            model=model, reasoning=ReActReasoning, include_default_tools=False
+        )
+
+        assert agent.tool_manager.has_tool("custom_domain_tool")
+        for name in INBUILT_TOOL_NAMES:
+            assert not agent.tool_manager.has_tool(name)
+    finally:
+        _GLOBAL_TOOL_REGISTRY.pop("custom_domain_tool", None)


### PR DESCRIPTION
Fixes #254

## Summary

When an agent registers only domain-specific tools (e.g. `adopt_opinion`), the LLM executor can still call inbuilt tools like `move_one_step` — even when the simulation has nothing to do with movement.

This happens because `ToolManager` auto-registers inbuilt tools globally, with no way to opt out. When the executor must choose a tool, it may select these unintended defaults.

## Changes

- Added `INBUILT_TOOL_NAMES` (frozenset) in `inbuilt_tools.py` to centrally define default tool names
- Added `include_default_tools: bool = True` parameter to `LLMAgent.__init__()`
  - `True` (default): preserves existing behavior (fully backward compatible)
  - `False`: filters out inbuilt tools (`move_one_step`, `teleport_to_location`, `speak_to`) from the agent’s `ToolManager`, leaving only user-registered tools
- Added tests covering:
  - default behavior (inbuilt tools present)
  - opt-out behavior (inbuilt tools removed)
  - preservation of user-defined tools

## Implementation Note

Filtering is applied after tool registration, ensuring compatibility with the existing tool registration flow while allowing selective removal of default tools per agent.

## Usage

```python
agent = LLMAgent(
    model=model,
    reasoning=CoTReasoning,
    include_default_tools=False,  # only domain tools visible to LLM
)