### PR TITLE
fix: replace deprecated seed= with rng= in all example models

### DIFF
--- a/examples/epstein_civil_violence/app.py
+++ b/examples/epstein_civil_violence/app.py
@@ -38,7 +38,7 @@ agent_colors = {
 }
 
 model_params = {
-    "seed": {
+    "rng": {
         "type": "InputText",
         "value": 42,
         "label": "Random Seed",
@@ -62,7 +62,7 @@ model = EpsteinModel(
     reasoning=model_params["reasoning"],
     llm_model=model_params["llm_model"],
     vision=model_params["vision"],
-    seed=model_params["seed"]["value"],
+    rng=model_params["rng"]["value"],
     parallel_stepping=model_params["parallel_stepping"],
 )
 

--- a/examples/epstein_civil_violence/model.py
+++ b/examples/epstein_civil_violence/model.py
@@ -20,9 +20,9 @@ class EpsteinModel(Model):
         llm_model: str,
         vision: int,
         parallel_stepping=True,
-        seed=None,
+        rng=None,
     ):
-        super().__init__(seed=seed)
+        super().__init__(rng=rng)
         self.width = width
         self.height = height
         self.parallel_stepping = parallel_stepping

--- a/examples/negotiation/app.py
+++ b/examples/negotiation/app.py
@@ -31,7 +31,7 @@ load_dotenv()
 
 
 model_params = {
-    "seed": {
+    "rng": {
         "type": "InputText",
         "value": 42,
         "label": "Random Seed",
@@ -52,7 +52,7 @@ model = NegotiationModel(
     reasoning=model_params["reasoning"],
     llm_model=model_params["llm_model"],
     vision=model_params["vision"],
-    seed=model_params["seed"]["value"],
+    rng=model_params["rng"]["value"],
 )
 
 if __name__ == "__main__":

--- a/examples/negotiation/model.py
+++ b/examples/negotiation/model.py
@@ -29,10 +29,10 @@ class NegotiationModel(Model):
         reasoning: type[Reasoning],
         llm_model: str,
         vision: int,
-        seed=None,
+        rng=None,
         parallel_stepping=True,
     ):
-        super().__init__(seed=seed)
+        super().__init__(rng=rng)
         self.width = width
         self.height = height
         self.parallel_stepping = parallel_stepping

--- a/examples/sugarscrap_g1mt/app.py
+++ b/examples/sugarscrap_g1mt/app.py
@@ -30,7 +30,7 @@ load_dotenv()
 
 
 model_params = {
-    "seed": {
+    "rng": {
         "type": "InputText",
         "value": 42,
         "label": "Random Seed",
@@ -53,7 +53,7 @@ model = SugarScapeModel(
     reasoning=model_params["reasoning"],
     llm_model=model_params["llm_model"],
     vision=model_params["vision"],
-    seed=model_params["seed"]["value"],
+    rng=model_params["rng"]["value"],
     parallel_stepping=model_params["parallel_stepping"],
 )
 

--- a/examples/sugarscrap_g1mt/model.py
+++ b/examples/sugarscrap_g1mt/model.py
@@ -39,9 +39,9 @@ class SugarScapeModel(Model):
         llm_model: str,
         vision: int,
         parallel_stepping=True,
-        seed=None,
+        rng=None,
     ):
-        super().__init__(seed=seed)
+        super().__init__(rng=rng)
         self.width = width
         self.height = height
         self.parallel_stepping = parallel_stepping


### PR DESCRIPTION
Fixes part of #273
All three example models (negotiation, sugarscrap_g1mt, epstein_civil_violence) were using the deprecated seed= parameter in both model.py and app.py files. This causes it to create a FutureWarning in Mesa 3.5 and will break in Mesa 4.0.
This  replaces all occurrences of seed=None with rng=None in the function signatures and super().__init__(seed=seed) with super().__init__(rng=rng) in all three examples.
All 285 tests pass after the changes made.
